### PR TITLE
feat: redesign and added openable local recording child

### DIFF
--- a/lib/auth/login.dart
+++ b/lib/auth/login.dart
@@ -1,31 +1,12 @@
-/*
- * Copyright (C) 2024 [Your Name]
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
- */
-import 'dart:math';
-
 import 'package:flutter/gestures.dart';
-import 'package:strnadi/auth/authorizator.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:logger/logger.dart';
-import 'package:strnadi/auth/register.dart';
-import 'package:strnadi/auth/registeration/mail.dart';
-import 'package:strnadi/recording/recorderWithSpectogram.dart';
-import 'package:strnadi/recording/streamRec.dart';
+import '../recording/streamRec.dart';
+import 'registeration/mail.dart';
 
 final logger = Logger();
 
@@ -37,7 +18,6 @@ class Login extends StatefulWidget {
 }
 
 class _LoginState extends State<Login> {
-  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
   late TapGestureRecognizer _registerTapRecognizer;
@@ -62,69 +42,28 @@ class _LoginState extends State<Login> {
     super.dispose();
   }
 
-  void checkAuth() async {
-    final secureStorage = FlutterSecureStorage();
-    var containsKey = await secureStorage.containsKey(key: 'token');
-
-    if (containsKey) {
-      Navigator.push(context, MaterialPageRoute(builder: (_) => LiveRec()));
-    }
-  }
-
   void login() async {
-    final secureStorage = FlutterSecureStorage();
-
-    final email = _emailController.text;
-    final password = _passwordController.text;
-
-    if (email.isEmpty || password.isEmpty) {
-      _showMessage('Please fill in both fields');
-      logger.i("email/password empty");
-      return;
-    }
-
-    final url = Uri(
-        scheme: 'https',
-        host: 'strnadiapi.slavetraders.tech',
-        path: '/auth/login');
-
+    final url = Uri.https('strnadiapi.slavetraders.tech', '/auth/login');
     try {
       final response = await http.post(
         url,
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: {'Content-Type': 'application/json'},
         body: jsonEncode({
-          'email': email,
-          'password': password,
+          'email': _emailController.text,
+          'password': _passwordController.text,
         }),
       );
 
-      if (response.statusCode == 202 || response.statusCode == 200) {
-        //202 -- Accepted
-        final data = response.body;
-
-        secureStorage.write(key: 'token', value: data.toString());
-
-        logger.i('logged in successfully');
-
-        Navigator.push(
-          context,
-          MaterialPageRoute(builder: (_) => LiveRec()),
-        );
-      } else if (response.statusCode == 401) {
-        _showMessage('Uživatel s daným emailem a heslem neexistuje');
-        logger.w("User already exists");
+      if (response.statusCode == 200 || response.statusCode == 202) {
+        await const FlutterSecureStorage()
+            .write(key: 'token', value: response.body);
+        Navigator.push(context, MaterialPageRoute(builder: (_) => LiveRec()));
       } else {
-        _showMessage('Nastala chyba :( Zkuste to znovu');
-        logger.e(response);
-        print('Login failed: ${response.statusCode}');
-        print('Error: ${response.body}');
+        _showMessage('Přihlášení selhalo, zkuste to znovu');
       }
     } catch (error) {
       logger.e(error);
-      _showMessage('Nastala chyba :( Zkuste to znovu');
-      print('An error occurred: $error');
+      _showMessage('Chyba připojení');
     }
   }
 
@@ -132,14 +71,8 @@ class _LoginState extends State<Login> {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Login'),
         content: Text(message),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('OK'),
-          ),
-        ],
+        actions: [TextButton(onPressed: () => Navigator.pop(context), child: const Text('OK'))],
       ),
     );
   }
@@ -147,118 +80,83 @@ class _LoginState extends State<Login> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(),
-      body: SingleChildScrollView(
-        child: IntrinsicHeight(
-          child: Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Column(
-              // Center the content vertically if possible.
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                const Text(
-                  'Strnadi',
-                  style: TextStyle(fontSize: 60),
-                  textAlign: TextAlign.center,
+      backgroundColor: Colors.white,
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Padding(
+          padding: const EdgeInsets.only(bottom: 100),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Text('Strnadi',
+                  style: TextStyle(fontSize: 70, fontWeight: FontWeight.bold, color: Colors.black),
+                  textAlign: TextAlign.center),
+              const SizedBox(height: 24),
+              TextField(
+                controller: _emailController,
+                decoration: InputDecoration(
+                  labelText: 'Email',
+                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
                 ),
-                const SizedBox(height: 20),
-                Form(
-                  key: _formKey,
-                  child: Column(
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _passwordController,
+                obscureText: true,
+                decoration: InputDecoration(
+                  labelText: 'Heslo',
+                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+                ),
+              ),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerRight,
+                child: Text('Zapomenuté heslo?', style: TextStyle(color: Colors.grey)),
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.black,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                ),
+                onPressed: login,
+                child: const Text('Přihlásit se'),
+              ),
+              const SizedBox(height: 16),
+              Center(
+                child: RichText(
+                  text: TextSpan(
+                    text: 'Nemáte účet? ',
+                    style: const TextStyle(color: Colors.black),
                     children: [
-                      TextFormField(
-                        controller: _emailController,
-                        textAlign: TextAlign.center,
-                        decoration: InputDecoration(
-                          label: RichText(
-                            text: TextSpan(
-                              text: 'Email',
-                              children: const <TextSpan>[
-                                TextSpan(
-                                  text: ' *',
-                                  style: TextStyle(color: Colors.red),
-                                ),
-                              ],
-                            ),
-                          ),
-                          border: const OutlineInputBorder(),
-                        ),
-                        keyboardType: TextInputType.emailAddress,
-                        validator: (value) {
-                          if (value == null || value.isEmpty) {
-                            return 'Please enter some text';
-                          }
-                          if (!RegExp(
-                                  r"^[a-zA-Z0-9.a-zA-Z0-9.!#$%&'*+-/=?^_`{|}~]+@[a-zA-Z0-9]+\.[a-zA-Z]+")
-                              .hasMatch(value)) {
-                            return 'Enter valid email';
-                          }
-                          return null;
-                        },
-                      ),
-                      const SizedBox(height: 20),
-                      TextFormField(
-                        controller: _passwordController,
-                        textAlign: TextAlign.center,
-                        decoration: InputDecoration(
-                          label: RichText(
-                            text: TextSpan(
-                              text: 'Password',
-                              children: const <TextSpan>[
-                                TextSpan(
-                                  text: ' *',
-                                  style: TextStyle(color: Colors.red),
-                                ),
-                              ],
-                            ),
-                          ),
-                          border: const OutlineInputBorder(),
-                        ),
-                        obscureText: true,
-                        keyboardType: TextInputType.visiblePassword,
-                        validator: (value) {
-                          if (value == null || value.isEmpty) {
-                            return 'Please enter some text';
-                          }
-                          return null;
-                        },
-                      ),
-                      const SizedBox(height: 20),
-                      ElevatedButton(
-                        style: ButtonStyle(
-                          shape:
-                              MaterialStateProperty.all<RoundedRectangleBorder>(
-                            RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(10.0),
-                            ),
-                          ),
-                        ),
-                        onPressed: login,
-                        child: const Text('Submit'),
-                      ),
-                      const SizedBox(height: 20),
-                      RichText(
-                        text: TextSpan(
-                          text: "Nemáte účet? ",
-                          style: const TextStyle(color: Colors.white),
-                          children: <TextSpan>[
-                            TextSpan(
-                              text: "Zaregistrovat se",
-                              style: const TextStyle(
-                                fontWeight: FontWeight.bold,
-                                color: Colors.blue,
-                              ),
-                              recognizer: _registerTapRecognizer,
-                            ),
-                          ],
-                        ),
+                      TextSpan(
+                        text: 'Zaregistrovat se',
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                        recognizer: _registerTapRecognizer,
                       ),
                     ],
                   ),
                 ),
-              ],
-            ),
+              ),
+              const SizedBox(height: 24),
+              Center(
+                child: Text.rich(
+                  TextSpan(
+                    text: 'pokračováním souhlasíte s ',
+                    style: const TextStyle(color: Colors.grey, fontSize: 12),
+                    children: [
+                      TextSpan(
+                        text: 'zásadami ochrany osobních údajů.',
+                        style: const TextStyle(color: Colors.black, fontWeight: FontWeight.bold),
+                      ),
+                    ],
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/bottomBar.dart
+++ b/lib/bottomBar.dart
@@ -51,6 +51,7 @@ class ScaffoldWithBottomBar extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: Center(child: Text(appBarTitle)),
+        backgroundColor: Colors.white,
         actions: [
           if (logout != null)
             IconButton(
@@ -62,6 +63,7 @@ class ScaffoldWithBottomBar extends StatelessWidget {
         ],
         automaticallyImplyLeading: false,
       ),
+      backgroundColor: Colors.white,
       body: SizedBox(
         height: MediaQuery.of(context).size.height -
             kToolbarHeight -
@@ -80,6 +82,7 @@ class ReusableBottomAppBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BottomAppBar(
+      color: Colors.white,
       shape: const CircularNotchedRectangle(),
       notchMargin: 8.0,
       padding: const EdgeInsets.symmetric(horizontal: 30.0),

--- a/lib/localRecordings/recList.dart
+++ b/lib/localRecordings/recList.dart
@@ -15,6 +15,7 @@
  */
 import 'package:flutter/material.dart';
 import 'package:strnadi/bottomBar.dart';
+import 'package:strnadi/localRecordings/recListItem.dart';
 import 'package:strnadi/localRecordings/recordingsDb.dart';
 
 class RecordItem {
@@ -50,7 +51,7 @@ class _RecordingScreenState extends State<RecordingScreen> {
   @override
   Widget build(BuildContext context) {
     // Sample data matching the screenshot
-    var records = list;
+    var records = list.reversed.toList();
     return ScaffoldWithBottomBar(
       appBarTitle: 'Záznamy',
       content: Padding(
@@ -91,7 +92,14 @@ class _RecordingScreenState extends State<RecordingScreen> {
                 color: Colors.grey,
               ),
               contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-              onTap: () {},
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => RecordingItem(recording: records[index]),
+                  ),
+                );
+              },
             );
           },
         ),

--- a/lib/localRecordings/recListItem.dart
+++ b/lib/localRecordings/recListItem.dart
@@ -1,0 +1,77 @@
+import 'package:audioplayers/audioplayers.dart';
+import 'package:flutter/material.dart';
+import 'package:strnadi/bottomBar.dart';
+import 'package:strnadi/localRecordings/recList.dart';
+import 'package:strnadi/localRecordings/recordingsDb.dart';
+import 'package:strnadi/widgets/spectogram_painter.dart';
+
+import '../HealthCheck/serverHealth.dart';
+
+
+class RecordingItem extends StatefulWidget {
+  final RecordItem recording;
+
+  const RecordingItem({Key? key, required this.recording}) : super(key: key);
+
+  @override
+  _RecordingItemState createState() => _RecordingItemState();
+}
+
+class _RecordingItemState extends State<RecordingItem>{
+
+  late String _filepath;
+
+  var player = AudioPlayer();
+
+  void getData() async{
+    var db =await LocalDb.database;
+
+    var filepath = await db.rawQuery("SELECT filepath FROM recordings WHERE title = ?", [widget.recording.title]);
+    var ret = filepath[0]["filepath"].toString();
+
+    _filepath = ret;
+
+    setState(() {});
+  }
+
+  void togglePlay() async {
+    if (player.state == PlayerState.playing) {
+      await player.pause();
+    } else {
+      await player.play(DeviceFileSource(_filepath));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    getData();
+    double width = MediaQuery.of(context).size.width;
+
+    return ScaffoldWithBottomBar(
+        appBarTitle: widget.recording.title,
+        content: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          children: [
+            Center(
+              child: Column(
+                children: [
+                  SizedBox(
+                      width: width,
+                      height: 200,
+                      child: LiveSpectogram.SpectogramLive(data: [], filepath: _filepath)
+                  ),
+                  ElevatedButton(
+                    onPressed: () {
+                      togglePlay();
+                    },
+                    child: player.state == PlayerState.paused ? Icon(Icons.play_arrow) : Icon(Icons.pause),
+                  ),
+                ],
+              ),
+            )
+          ],
+        )
+    );
+  }
+
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -99,7 +99,12 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      theme: ThemeData.dark(),
+      theme: ThemeData(
+        appBarTheme: const AppBarTheme(
+          backgroundColor: Colors.white,
+          elevation: 0,
+        ),
+      ),
       home: const HomeScreen(),
     );
   }

--- a/lib/recording/streamRec.dart
+++ b/lib/recording/streamRec.dart
@@ -252,7 +252,7 @@ class _LiveRecState extends State<LiveRec> {
   @override
   Widget build(BuildContext context) {
     return ScaffoldWithBottomBar(
-      appBarTitle: "Live Recorder",
+      appBarTitle: "",
       content: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
@@ -263,8 +263,6 @@ class _LiveRecState extends State<LiveRec> {
               _buildRecordStopControl(),
               const SizedBox(width: 20),
               _buildPauseResumeControl(),
-              const SizedBox(width: 20),
-              _buildText(),
             ],
           ),
           if (_amplitude != null) ...[
@@ -288,15 +286,12 @@ class _LiveRecState extends State<LiveRec> {
 
   Widget _buildRecordStopControl() {
     late Icon icon;
-    late Color color;
 
     if (_recordState != RecordState.stop) {
       icon = const Icon(Icons.stop, color: Colors.red, size: 30);
-      color = Colors.red.withValues(alpha: 0.1);
     } else {
       final theme = Theme.of(context);
       icon = Icon(Icons.mic, color: theme.primaryColor, size: 30);
-      color = theme.primaryColor.withValues(alpha: 0.1);
     }
 
     return ClipOval(
@@ -342,13 +337,6 @@ class _LiveRecState extends State<LiveRec> {
     );
   }
 
-  Widget _buildText() {
-    if (_recordState != RecordState.stop) {
-      return _buildTimer();
-    }
-
-    return const Text("Waiting to record");
-  }
 
   Widget _buildTimer() {
     final String minutes = _formatNumber(_recordDuration ~/ 60);


### PR DESCRIPTION
This pull request includes significant changes to the `lib/auth/login.dart` file, updates to the UI and functionality of various components, and the addition of a new recording item feature. The most important changes include refactoring the `login` method, updating the UI for a more modern look, and adding a new screen for individual recording items.

### Changes to `lib/auth/login.dart`:

* Refactored the `login` method to simplify the code and improve error handling. Removed the `checkAuth` method and redundant code.
* Updated the UI to use `TextField` instead of `TextFormField`, added padding, and made the design more consistent with modern standards.

### UI Updates:

* Changed the background color of the `Scaffold`, `AppBar`, and `BottomAppBar` to white in `lib/bottomBar.dart`. [[1]](diffhunk://#diff-3205b3e3929e5f7e51aef8c9fdffb31ac98fe6c123a003db0d88c67155bee2c4R54) [[2]](diffhunk://#diff-3205b3e3929e5f7e51aef8c9fdffb31ac98fe6c123a003db0d88c67155bee2c4R66) [[3]](diffhunk://#diff-3205b3e3929e5f7e51aef8c9fdffb31ac98fe6c123a003db0d88c67155bee2c4R85)
* Reversed the order of the recordings list and added navigation to a new recording item screen in `lib/localRecordings/recList.dart`. [[1]](diffhunk://#diff-1a803bbdd5a7e5c347d3d9d6e5f2b91c82e05ae40a83ae06c36b13caa85ed3b3L53-R54) [[2]](diffhunk://#diff-1a803bbdd5a7e5c347d3d9d6e5f2b91c82e05ae40a83ae06c36b13caa85ed3b3L94-R102)
* Updated the theme in `lib/main.dart` to use a custom theme with a white `AppBar`.

### New Features:

* Added a new `RecordingItem` screen in `lib/localRecordings/recListItem.dart` to display and play individual recordings.

### Miscellaneous:

* Removed the `GlobalKey<FormState>` and unused imports in `lib/auth/login.dart`.
* Removed unnecessary UI elements and simplified the recording controls in `lib/recording/streamRec.dart`. [[1]](diffhunk://#diff-9de28d0bfc527225fd9526ff1a6ee49e16ba8a48d078ba40ae513c537e1def82L255-R255) [[2]](diffhunk://#diff-9de28d0bfc527225fd9526ff1a6ee49e16ba8a48d078ba40ae513c537e1def82L266-L267) [[3]](diffhunk://#diff-9de28d0bfc527225fd9526ff1a6ee49e16ba8a48d078ba40ae513c537e1def82L291-L299) [[4]](diffhunk://#diff-9de28d0bfc527225fd9526ff1a6ee49e16ba8a48d078ba40ae513c537e1def82L345-L351)