### PR TITLE
bettered notifications

### DIFF
--- a/lib/firebase/firebase.dart
+++ b/lib/firebase/firebase.dart
@@ -126,7 +126,6 @@ Future<void> initFirebaseMessaging() async{
   messaging.getToken().then((token) async {
     logger.i("Firebase token: $token");
 
-    FlutterSecureStorage().write(key: 'fcmToken', value: token);
     Uri url = Uri.https('api.strnadi.cz', '/devices/device');
 
     try {
@@ -155,7 +154,7 @@ Future<void> initFirebaseMessaging() async{
         FlutterSecureStorage().write(key: 'fcmToken', value: token);
       }
       else {
-        logger.e('Failed to send token to server', error: response.body);
+        logger.e('Failed to send token to server ${response.statusCode}');
       }
     }
     catch (error) {
@@ -190,7 +189,7 @@ Future<void> initFirebaseMessaging() async{
         logger.i('Token refreshed');
       }
       else {
-        logger.e('Failed to refresh token', error: response.body);
+        logger.e('Failed to refresh token ${response.statusCode}');
       }
     }
     catch (error) {
@@ -234,7 +233,7 @@ void deleteToken() async{
       logger.i('Token deleted');
     }
     else{
-      logger.e('Failed to delete token', error: response.body);
+      logger.e('Failed to delete token ${response.statusCode}');
     }
   }
   catch (error){


### PR DESCRIPTION
This pull request includes several changes to improve error logging in the Firebase messaging initialization and token management functions. The most important changes focus on enhancing the error messages by including the HTTP status code in the logs.

Improvements to error logging:

* [`lib/firebase/firebase.dart`](diffhunk://#diff-56d8f132eea2d77c98a9e644a7e890d39538e32a73b86da966d3f0f46e774918L158-R157): In the `initFirebaseMessaging` function, modified the error logging to include the HTTP status code when sending the token to the server fails.
* [`lib/firebase/firebase.dart`](diffhunk://#diff-56d8f132eea2d77c98a9e644a7e890d39538e32a73b86da966d3f0f46e774918L193-R192): In the `initFirebaseMessaging` function, modified the error logging to include the HTTP status code when refreshing the token fails.
* [`lib/firebase/firebase.dart`](diffhunk://#diff-56d8f132eea2d77c98a9e644a7e890d39538e32a73b86da966d3f0f46e774918L237-R236): In the `deleteToken` function, modified the error logging to include the HTTP status code when deleting the token fails.

Code cleanup:

* [`lib/firebase/firebase.dart`](diffhunk://#diff-56d8f132eea2d77c98a9e644a7e890d39538e32a73b86da966d3f0f46e774918L129): Removed redundant token storage operation in the `initFirebaseMessaging` function.