### PR TITLE
fixed merge

### DIFF
--- a/lib/PostRecordingForm/RecordingForm.dart
+++ b/lib/PostRecordingForm/RecordingForm.dart
@@ -304,6 +304,19 @@ class _RecordingFormState extends State<RecordingForm> {
       logger.e(error);
       Navigator.push(context, MaterialPageRoute(builder: (context) => LiveRec()));
     }
+    LocalDb.insertRecording(
+      rec,
+      _recordingNameController.text,
+      0,
+      widget.filepath,
+      widget.currentPosition?.latitude ?? 0,
+      widget.currentPosition?.longitude ?? 0,
+      widget.recordingParts,
+      widget.recordingPartsTimeList,
+      widget.startTime,
+      _recordingId ?? -1,
+    );
+    logger.i("inserted into local db");
   }
 
   // New method to handle each new position update
@@ -328,21 +341,7 @@ class _RecordingFormState extends State<RecordingForm> {
       }
     });
   }
-    LocalDb.insertRecording(
-      rec,
-      _recordingNameController.text,
-      0,
-      widget.filepath,
-      widget.currentPosition?.latitude ?? 0,
-      widget.currentPosition?.longitude ?? 0,
-      widget.recordingParts,
-      widget.recordingPartsTimeList,
-      widget.startTime,
-      _recordingId ?? -1,
-    );
-    logger.i("inserted into local db");
 
-  }
   void seekRelative(int seconds) {
     final newPosition = currentPosition + Duration(seconds: seconds);
     _audioPlayer.seek(newPosition);


### PR DESCRIPTION
This pull request includes changes to the `RecordingForm` class in the `lib/PostRecordingForm/RecordingForm.dart` file. The main focus of these changes is to refactor the code related to inserting recordings into the local database.

Refactoring for database insertion:

* Moved the `LocalDb.insertRecording` call and the associated logging statement to a different location within the `_RecordingFormState` class. This refactoring improves code organization and readability. [[1]](diffhunk://#diff-b0511e86f9fac90200a78ac64abe8d98ababb85f18f1ddccff3b420eabb1becdR307-R319) [[2]](diffhunk://#diff-b0511e86f9fac90200a78ac64abe8d98ababb85f18f1ddccff3b420eabb1becdL331-L345)