### PR TITLE
postRecordingForm fixes

### DIFF
--- a/lib/PostRecordingForm/RecordingForm.dart
+++ b/lib/PostRecordingForm/RecordingForm.dart
@@ -2,6 +2,7 @@
  * RecordingForm.dart
  */
 
+import 'dart:ffi';
 import 'dart:io';
 import 'dart:async';
 import 'package:just_audio/just_audio.dart';
@@ -359,190 +360,194 @@ class _RecordingFormState extends State<RecordingForm> {
         ? LatLng(locationService.lastKnownPosition!.latitude, locationService.lastKnownPosition!.longitude)
         : null;
     final halfScreen = MediaQuery.of(context).size.width * 0.45;
-    return SingleChildScrollView(
-      child: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.spaceAround,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            SizedBox(
-              height: 300,
-              width: double.infinity,
-              child: spectogram,
-            ),
-            Text(_formatDuration(totalDuration), style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                IconButton(icon: const Icon(Icons.replay_10, size: 32), onPressed: () => seekRelative(-10)),
-                IconButton(
-                  icon: Icon(isPlaying ? Icons.pause_circle_filled : Icons.play_circle_filled),
-                  iconSize: 72,
-                  onPressed: togglePlay,
-                ),
-                IconButton(icon: const Icon(Icons.forward_10, size: 32), onPressed: () => seekRelative(10)),
-              ],
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 16.0),
-              child: ElevatedButton.icon(
-                icon: const Icon(Icons.add),
-                label: const Text('Přidat dialekt'),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: const Color(0xFFFFF7C0),
-                  foregroundColor: Colors.black,
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                ),
-                onPressed: _showDialectSelectionDialog,
+    return PopScope(
+      canPop: false,
+      //onPopInvokedWithResult: Navigator.pushReplacement(context, MaterialPageRoute(builder: (context) => LiveRec())),
+      child: SingleChildScrollView(
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              SizedBox(
+                height: 300,
+                width: double.infinity,
+                child: spectogram,
               ),
-            ),
-            if (dialectSegments.isNotEmpty)
-              Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: dialectSegments.map((dialect) => _buildDialectSegment(dialect)).toList(),
-                ),
-              ),
-            const SizedBox(height: 50),
-            SizedBox(
-              height: 200,
-              child: Stack(
+              Text(_formatDuration(totalDuration), style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  FlutterMap(
-                    options: MapOptions(
-                      initialCenter: _computedCenter,
-                      initialZoom: _computedZoom,
-                      interactionOptions: InteractionOptions(flags: InteractiveFlag.none),
-                    ),
-                    children: [
-                      TileLayer(
-                        urlTemplate:
-                        'https://api.mapy.cz/v1/maptiles/outdoor/256/{z}/{x}/{y}?apikey=$MAPY_CZ_API_KEY',
-                        userAgentPackageName: 'cz.delta.strnadi',
-                      ),
-                      if (_route.isNotEmpty)
-                        PolylineLayer(
-                          polylines: [
-                            Polyline(points: List.from(_route), strokeWidth: 4.0, color: Colors.blue),
-                          ],
-                        ),
-                      // MarkerLayer(
-                      //   markers: [
-                      //     if (markerPosition != null)
-                      //       Marker(
-                      //         width: 20.0,
-                      //         height: 20.0,
-                      //         point: markerPosition!,
-                      //         child: const Icon(
-                      //           Icons.my_location,
-                      //           color: Colors.blue,
-                      //           size: 30.0,
-                      //         ),
-                      //       ),
-                      //     ...recordingParts.map(
-                      //           (part) => Marker(
-                      //         width: 20.0,
-                      //         height: 20.0,
-                      //         point: LatLng(part.gpsLatitudeEnd, part.gpsLongitudeEnd),
-                      //         child: const Icon(
-                      //           Icons.location_on,
-                      //           color: Colors.red,
-                      //           size: 30.0,
-                      //         ),
-                      //       ),
-                      //     ),
-                      //   ],
-                      // ),
-                    ],
+                  IconButton(icon: const Icon(Icons.replay_10, size: 32), onPressed: () => seekRelative(-10)),
+                  IconButton(
+                    icon: Icon(isPlaying ? Icons.pause_circle_filled : Icons.play_circle_filled),
+                    iconSize: 72,
+                    onPressed: togglePlay,
                   ),
+                  IconButton(icon: const Icon(Icons.forward_10, size: 32), onPressed: () => seekRelative(10)),
                 ],
               ),
-            ),
-            const SizedBox(height: 20),
-            Form(
-              child: Padding(
-                padding: const EdgeInsets.all(10.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.center,
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16.0),
+                child: ElevatedButton.icon(
+                  icon: const Icon(Icons.add),
+                  label: const Text('Přidat dialekt'),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFFFFF7C0),
+                    foregroundColor: Colors.black,
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                  ),
+                  onPressed: _showDialectSelectionDialog,
+                ),
+              ),
+              if (dialectSegments.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: dialectSegments.map((dialect) => _buildDialectSegment(dialect)).toList(),
+                  ),
+                ),
+              const SizedBox(height: 50),
+              SizedBox(
+                height: 200,
+                child: Stack(
                   children: [
-                    TextFormField(
-                      controller: _recordingNameController,
-                      textAlign: TextAlign.center,
-                      decoration: const InputDecoration(
-                        labelText: 'Nazev Nahravky',
-                        border: OutlineInputBorder(),
+                    FlutterMap(
+                      options: MapOptions(
+                        initialCenter: _computedCenter,
+                        initialZoom: _computedZoom,
+                        interactionOptions: InteractionOptions(flags: InteractiveFlag.none),
                       ),
-                      keyboardType: TextInputType.text,
-                      validator: (value) => (value == null || value.isEmpty) ? 'Please enter some text' : null,
-                    ),
-                    const SizedBox(height: 20),
-                    TextFormField(
-                      textAlign: TextAlign.center,
-                      controller: _commentController,
-                      decoration: const InputDecoration(
-                        labelText: 'Komentar',
-                        border: OutlineInputBorder(),
-                      ),
-                      keyboardType: TextInputType.text,
-                      validator: (value) => (value == null || value.isEmpty) ? 'Please enter some text' : null,
-                    ),
-                    const SizedBox(height: 20),
-                    Slider(
-                      value: _strnadiCountController,
-                      min: 1,
-                      max: 3,
-                      divisions: 2,
-                      label: "Pocet Strnadi",
-                      onChanged: (value) => setState(() => _strnadiCountController = value),
-                    ),
-                    MultiPhotoUploadWidget(onImagesSelected: _onImagesSelected),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                       children: [
-                        Padding(
-                          padding: const EdgeInsets.symmetric(vertical: 20),
-                          child: SizedBox(
-                            width: halfScreen,
-                            child: ElevatedButton(
-                              style: ButtonStyle(
-                                shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                                  RoundedRectangleBorder(borderRadius: BorderRadius.circular(10.0)),
-                                ),
-                              ),
-                              onPressed: upload,
-                              child: const Text('Submit'),
-                            ),
-                          ),
+                        TileLayer(
+                          urlTemplate:
+                          'https://api.mapy.cz/v1/maptiles/outdoor/256/{z}/{x}/{y}?apikey=$MAPY_CZ_API_KEY',
+                          userAgentPackageName: 'cz.delta.strnadi',
                         ),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(vertical: 20),
-                          child: SizedBox(
-                            width: halfScreen,
-                            child: ElevatedButton(
-                              style: ButtonStyle(
-                                shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                                  RoundedRectangleBorder(borderRadius: BorderRadius.circular(10.0)),
-                                ),
-                              ),
-                              onPressed: () {
-                                spectogramKey = GlobalKey();
-                                Navigator.push(context, MaterialPageRoute(builder: (context) => LiveRec()));
-                              },
-                              child: const Text('Discard'),
-                            ),
+                        if (_route.isNotEmpty)
+                          PolylineLayer(
+                            polylines: [
+                              Polyline(points: List.from(_route), strokeWidth: 4.0, color: Colors.blue),
+                            ],
                           ),
-                        ),
+                        // MarkerLayer(
+                        //   markers: [
+                        //     if (markerPosition != null)
+                        //       Marker(
+                        //         width: 20.0,
+                        //         height: 20.0,
+                        //         point: markerPosition!,
+                        //         child: const Icon(
+                        //           Icons.my_location,
+                        //           color: Colors.blue,
+                        //           size: 30.0,
+                        //         ),
+                        //       ),
+                        //     ...recordingParts.map(
+                        //           (part) => Marker(
+                        //         width: 20.0,
+                        //         height: 20.0,
+                        //         point: LatLng(part.gpsLatitudeEnd, part.gpsLongitudeEnd),
+                        //         child: const Icon(
+                        //           Icons.location_on,
+                        //           color: Colors.red,
+                        //           size: 30.0,
+                        //         ),
+                        //       ),
+                        //     ),
+                        //   ],
+                        // ),
                       ],
                     ),
                   ],
                 ),
               ),
-            ),
-          ],
+              const SizedBox(height: 20),
+              Form(
+                child: Padding(
+                  padding: const EdgeInsets.all(10.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      TextFormField(
+                        controller: _recordingNameController,
+                        textAlign: TextAlign.center,
+                        decoration: const InputDecoration(
+                          labelText: 'Nazev Nahravky',
+                          border: OutlineInputBorder(),
+                        ),
+                        keyboardType: TextInputType.text,
+                        validator: (value) => (value == null || value.isEmpty) ? 'Please enter some text' : null,
+                      ),
+                      const SizedBox(height: 20),
+                      TextFormField(
+                        textAlign: TextAlign.center,
+                        controller: _commentController,
+                        decoration: const InputDecoration(
+                          labelText: 'Komentar',
+                          border: OutlineInputBorder(),
+                        ),
+                        keyboardType: TextInputType.text,
+                        validator: (value) => (value == null || value.isEmpty) ? 'Please enter some text' : null,
+                      ),
+                      const SizedBox(height: 20),
+                      Slider(
+                        value: _strnadiCountController,
+                        min: 1,
+                        max: 3,
+                        divisions: 2,
+                        label: "Pocet Strnadi",
+                        onChanged: (value) => setState(() => _strnadiCountController = value),
+                      ),
+                      MultiPhotoUploadWidget(onImagesSelected: _onImagesSelected),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        children: [
+                          Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 20),
+                            child: SizedBox(
+                              width: halfScreen,
+                              child: ElevatedButton(
+                                style: ButtonStyle(
+                                  shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                                    RoundedRectangleBorder(borderRadius: BorderRadius.circular(10.0)),
+                                  ),
+                                ),
+                                onPressed: upload,
+                                child: const Text('Submit'),
+                              ),
+                            ),
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 20),
+                            child: SizedBox(
+                              width: halfScreen,
+                              child: ElevatedButton(
+                                style: ButtonStyle(
+                                  shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                                    RoundedRectangleBorder(borderRadius: BorderRadius.circular(10.0)),
+                                  ),
+                                ),
+                                onPressed: () {
+                                  spectogramKey = GlobalKey();
+                                  Navigator.push(context, MaterialPageRoute(builder: (context) => LiveRec()));
+                                },
+                                child: const Text('Discard'),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
-      ),
+      )
     );
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,11 +29,9 @@ import 'package:strnadi/updateChecker.dart';
 import 'firebase/firebase.dart';
 import 'package:google_api_availability/google_api_availability.dart';
 import 'config/config.dart';
-import 'package:strnadi/archived/recordingsDb.dart';
 import 'package:strnadi/database/databaseNew.dart';
 import 'package:strnadi/callback_dispatcher.dart';
 import 'package:workmanager/workmanager.dart';
-
 
 // Create a global logger instance.
 final logger = Logger();

--- a/lib/recording/streamRec.dart
+++ b/lib/recording/streamRec.dart
@@ -238,7 +238,7 @@ class _LiveRecState extends State<LiveRec> {
       context,
       MaterialPageRoute(
         builder: (context) => Scaffold(
-          appBar: AppBar(title: const Text("Recording Form")),
+          appBar: AppBar(title: const Text("Recording Form"), automaticallyImplyLeading: false,),
           body: RecordingForm(
             filepath: recordedFilePath!,
             startTime: overallStartTime!,


### PR DESCRIPTION
This pull request includes several changes to the `RecordingForm` and other related files to enhance the user interface and code structure. The most important changes include adding a new import, modifying the navigation behavior, and updating the app bar configuration.

### Changes to `RecordingForm` and related files:

* [`lib/PostRecordingForm/RecordingForm.dart`](diffhunk://#diff-b0511e86f9fac90200a78ac64abe8d98ababb85f18f1ddccff3b420eabb1becdR5): Added a new import for `dart:ffi`.
* [`lib/PostRecordingForm/RecordingForm.dart`](diffhunk://#diff-b0511e86f9fac90200a78ac64abe8d98ababb85f18f1ddccff3b420eabb1becdL362-R366): Wrapped the `SingleChildScrollView` widget with `PopScope` to prevent the user from navigating back. [[1]](diffhunk://#diff-b0511e86f9fac90200a78ac64abe8d98ababb85f18f1ddccff3b420eabb1becdL362-R366) [[2]](diffhunk://#diff-b0511e86f9fac90200a78ac64abe8d98ababb85f18f1ddccff3b420eabb1becdR550)

### Other changes:

* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L32-L37): Removed the import for `recordingsDb.dart` from the archived directory.
* [`lib/recording/streamRec.dart`](diffhunk://#diff-9de28d0bfc527225fd9526ff1a6ee49e16ba8a48d078ba40ae513c537e1def82L241-R241): Updated the app bar in `LiveRec` to disable the back button by setting `automaticallyImplyLeading` to `false`.