### PR TITLE
Licence add

### DIFF
--- a/lib/PostRecordingForm/RecordingForm.dart
+++ b/lib/PostRecordingForm/RecordingForm.dart
@@ -1,4 +1,19 @@
 /*
+ * Copyright (C) 2025 Marian Pecqueur && Jan Drobílek
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+/*
  * RecordingForm.dart
  */
 

--- a/lib/auth/registeration/mail.dart
+++ b/lib/auth/registeration/mail.dart
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2025 Marian Pecqueur && Jan Drobílek
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
 import 'package:flutter/gestures.dart';
 import 'package:strnadi/auth/authorizator.dart';
 import 'package:strnadi/auth/registeration/nameReg.dart';

--- a/lib/callback_dispatcher.dart
+++ b/lib/callback_dispatcher.dart
@@ -1,4 +1,19 @@
 /*
+ * Copyright (C) 2025 Marian Pecqueur && Jan Drobílek
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+/*
  * Callback_dispatcher.dart
  */
 

--- a/lib/localRecordings/recList.dart
+++ b/lib/localRecordings/recList.dart
@@ -1,4 +1,19 @@
 /*
+ * Copyright (C) 2025 Marian Pecqueur && Jan Drobílek
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+/*
  * recList.dart
  */
 

--- a/lib/localRecordings/recListItem.dart
+++ b/lib/localRecordings/recListItem.dart
@@ -1,4 +1,19 @@
 /*
+ * Copyright (C) 2025 Marian Pecqueur && Jan Drobílek
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+/*
  * recListItem.dart
  */
 

--- a/lib/map/searchBar.dart
+++ b/lib/map/searchBar.dart
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2025 Marian Pecqueur && Jan Drobílek
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
 import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';

--- a/lib/notificationPage/notifList.dart
+++ b/lib/notificationPage/notifList.dart
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2025 Marian Pecqueur && Jan Drobílek
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
 import 'package:flutter/material.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:strnadi/bottomBar.dart';

--- a/lib/notificationPage/notifications.dart
+++ b/lib/notificationPage/notifications.dart
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2025 Marian Pecqueur && Jan Drobílek
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
 import 'dart:convert';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;

--- a/lib/recording/streamRec.dart
+++ b/lib/recording/streamRec.dart
@@ -1,4 +1,19 @@
 /*
+ * Copyright (C) 2025 Marian Pecqueur && Jan Drobílek
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+/*
  * streamRec.dart
  */
 

--- a/lib/recording/waw.dart
+++ b/lib/recording/waw.dart
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2025 Marian Pecqueur && Jan Drobílek
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
 import 'dart:io';
 import 'dart:typed_data';
 import 'package:logger/logger.dart';


### PR DESCRIPTION
This pull request includes the addition of GPL license headers to several Dart files across the project. These changes ensure that the files are properly licensed under the GNU General Public License.

License header additions:

* [`lib/PostRecordingForm/RecordingForm.dart`](diffhunk://#diff-b0511e86f9fac90200a78ac64abe8d98ababb85f18f1ddccff3b420eabb1becdR1-R15): Added GPL license header.
* [`lib/auth/registeration/mail.dart`](diffhunk://#diff-d2199b882452dfc22233e4df00b5df413d9016b9622eb570509b97d5182c708dR1-R15): Added GPL license header.
* [`lib/callback_dispatcher.dart`](diffhunk://#diff-3c236dbcaf31faae2135590106e22ad31d7b136805109dd03c6cffdcc202b519R1-R15): Added GPL license header.
* [`lib/localRecordings/recList.dart`](diffhunk://#diff-1a803bbdd5a7e5c347d3d9d6e5f2b91c82e05ae40a83ae06c36b13caa85ed3b3R1-R15): Added GPL license header.
* [`lib/localRecordings/recListItem.dart`](diffhunk://#diff-121e51d5adfc2b2d6ebd888ba24c3336c93181fd463f3d78d30db78b2e5bd789R1-R15): Added GPL license header.
* [`lib/map/searchBar.dart`](diffhunk://#diff-9b16328a28f4bd323df4c970c56580bd412402c9c76beeb074eb08b8471a2282R1-R15): Added GPL license header.
* [`lib/notificationPage/notifList.dart`](diffhunk://#diff-1ab369fbb686c63c40f7f651126b906a0cbef447390b82a2914cd94f7fb31c22R1-R15): Added GPL license header.
* [`lib/notificationPage/notifications.dart`](diffhunk://#diff-9ba727a91ae308f84c133a021220cea60f7733e2e37eb3b8573918cdfb6b71d7R1-R15): Added GPL license header.
* [`lib/recording/streamRec.dart`](diffhunk://#diff-9de28d0bfc527225fd9526ff1a6ee49e16ba8a48d078ba40ae513c537e1def82R1-R15): Added GPL license header.
* [`lib/recording/waw.dart`](diffhunk://#diff-d3fbff6a8c3be716648be8cc1e7deec2a5691eb505f4d12b92ad72e262d742afR1-R15): Added GPL license header.