### PR TITLE
fix: fixed the topout behavior

### DIFF
--- a/lib/PostRecordingForm/RecordingForm.dart
+++ b/lib/PostRecordingForm/RecordingForm.dart
@@ -213,6 +213,8 @@ class _RecordingFormState extends State<RecordingForm> {
       spectogram = null;
     });
     showDialog(
+      // disable tap out hide
+      barrierDismissible: false,
       context: context,
       builder: (context) => DialectSelectionDialog(
         spectogram: spect!,

--- a/lib/recording/streamRec.dart
+++ b/lib/recording/streamRec.dart
@@ -36,6 +36,7 @@ import 'package:path_provider/path_provider.dart';
 import '../bottomBar.dart';
 import 'package:strnadi/locationService.dart';
 import 'package:strnadi/recording/waw.dart'; // Contains createWavHeader & concatWavFiles
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 final logger = Logger();
 
@@ -198,6 +199,7 @@ class _LiveRecState extends State<LiveRec> {
     if (_recordState == RecordState.record) {
       try {
         await _audioRecorder.stop();
+        WakelockPlus.disable(); // or WakelockPlus.toggle(on: false);
         _elapsedTimer.pause();
         setState(() {
           recording = false;
@@ -383,6 +385,7 @@ class _LiveRecState extends State<LiveRec> {
   }
 
   Future<void> _start() async {
+    WakelockPlus.enable(); // or WakelockPlus.toggle(on: false);
     try {
       logger.i('Started recording');
       if (await _audioRecorder.hasPermission()) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -91,6 +91,7 @@ dependencies:
   app_links: ^6.4.0
   google_sign_in: ^6.3.0
   firebase_auth: ^5.5.1
+  wakelock_plus: ^1.2.11
 
 
 dev_dependencies:


### PR DESCRIPTION
This pull request includes several changes to enhance the recording functionality and user experience in the app. The most important changes include adding the `wakelock_plus` dependency and ensuring the screen stays awake during recording sessions.

Enhancements to recording functionality:

* [`lib/recording/streamRec.dart`](diffhunk://#diff-9de28d0bfc527225fd9526ff1a6ee49e16ba8a48d078ba40ae513c537e1def82R202): Added `WakelockPlus` to keep the screen awake during recording sessions. Enabled wakelock at the start of recording and disabled it when recording stops. [[1]](diffhunk://#diff-9de28d0bfc527225fd9526ff1a6ee49e16ba8a48d078ba40ae513c537e1def82R202) [[2]](diffhunk://#diff-9de28d0bfc527225fd9526ff1a6ee49e16ba8a48d078ba40ae513c537e1def82R388)

Dependency updates:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25R94): Added the `wakelock_plus` dependency to the project.

User experience improvements:

* [`lib/PostRecordingForm/RecordingForm.dart`](diffhunk://#diff-b0511e86f9fac90200a78ac64abe8d98ababb85f18f1ddccff3b420eabb1becdR216-R217): Disabled the ability to dismiss the `DialectSelectionDialog` by tapping outside of it.