### PR TITLE
change fill all message

### DIFF
--- a/lib/auth/login.dart
+++ b/lib/auth/login.dart
@@ -68,7 +68,7 @@ class _LoginState extends State<Login> {
     final url = Uri.https(Config.host, '/auth/login');
 
     if (_emailController.text.isEmpty || _passwordController.text.isEmpty){
-      _showMessage("Vyplňte všechny pole");
+      _showMessage("Vyplňte jméno i heslo");
       return;
     }
 


### PR DESCRIPTION
This pull request includes a small change to the `lib/auth/login.dart` file. The change updates the error message shown when the email or password fields are empty. 

* [`lib/auth/login.dart`](diffhunk://#diff-a729bf362f5f3d67a7e87c195edd4b70d5b9416cbc7a5eb9d4a46eaeef7b2d43L71-R71): Changed the error message from "Vyplňte všechny pole" to "Vyplňte jméno i heslo" to provide more specific instructions to the user.