### PR TITLE
refactor: use structured translation keys

### DIFF
--- a/assets/lang/cs.json
+++ b/assets/lang/cs.json
@@ -1,178 +1,534 @@
 {
-  "2017": "2017",
-  "A new version ({version}) is available. Please update your app.": "A new version ({version}) is available. Please update your app.",
-  "Abychom vás mohli informovat ohledně zajímavostí z vaší lokality, budeme potřebovat vaše PSČ (použito pro cílení notifikací) a obec (město, které se zobrazí ostatním uživatelům). Tento krok je nepovinný.": "Abychom vás mohli informovat ohledně zajímavostí z vaší lokality, budeme potřebovat vaše PSČ (použito pro cílení notifikací) a obec (město, které se zobrazí ostatním uživatelům). Tento krok je nepovinný.",
-  "Ano": "Ano",
-  "Aplikace": "Aplikace",
-  "Aplikace i web stále procházejí velmi bouřlivým vývojem. Za chyby se omlouváme. Těšte se na časté aktualizace a vylepšování.": "Aplikace i web stále procházejí velmi bouřlivým vývojem. Za chyby se omlouváme. Těšte se na časté aktualizace a vylepšování.",
-  "Aplikace potřebuje povolení k mikrofonu a notifikacím.\\n": "Aplikace potřebuje povolení k mikrofonu a notifikacím.\\n",
-  "Autor nahrávky:": "Autor nahrávky:",
-  "Chci si smazat účet": "Chci si smazat účet",
-  "Chyba": "Chyba",
-  "Chybí připojení k internetu. Mapa není dostupná.": "Chybí připojení k internetu. Mapa není dostupná.",
-  "Could not launch": "Could not launch",
-  "Could not open the email app": "Could not open the email app",
-  "Creators: Marian Pecqueur && Jan Drobílek": "Creators: Marian Pecqueur && Jan Drobílek",
-  "Data:": "Data:",
-  "Datum a čas": "Datum a čas",
-  "Dobyté sektory:": "Dobyté sektory:",
-  "Dokončit a pokračovat": "Dokončit a pokračovat",
-  "E-mail": "E-mail",
-  "E-mail poslán": "E-mail poslán",
-  "Email již ověřen": "Email již ověřen",
-  "Email není ověřen": "Email není ověřen",
-  "Error deleting recording": "Error deleting recording",
-  "Error downloading recording": "Error downloading recording",
-  "Fotografie": "Fotografie",
-  "Heslo": "Heslo",
-  "Heslo *": "Heslo *",
-  "Heslo úspěšně změněno": "Heslo úspěšně změněno",
-  "I agree to the terms and conditions": "I agree to the terms and conditions",
-  "Informace": "Informace",
-  "Jméno *": "Jméno *",
-  "Jste offline. Budou dostupné pouze lokálně uložené záznamy.": "Jste offline. Budou dostupné pouze lokálně uložené záznamy.",
-  "Kde se nacházíte?": "Kde se nacházíte?",
-  "Klasické": "Klasické",
-  "Komentář": "Komentář",
-  "Kontakt: info@strnadi.cz, developers@strnadi.cz": "Kontakt: info@strnadi.cz, developers@strnadi.cz",
-  "Kraj": "Kraj",
-  "Legenda": "Legenda",
-  "Letecké": "Letecké",
-  "Login": "Login",
-  "Mapa": "Mapa",
-  "Mapu nelze načíst bez připojení k internetu.": "Mapu nelze načíst bez připojení k internetu.",
-  "Mapy.cz © Seznam.cz, a.s.": "Mapy.cz © Seznam.cz, a.s.",
-  "Message": "Message",
-  "Na tento e-mail vám pošleme instrukce pro reset hesla": "Na tento e-mail vám pošleme instrukce pro reset hesla",
-  "Na „{email}” jsme vám poslali odkaz na ověření e-mailové adresy. Kliknutím na odkaz potvrdíte svoji emailovou adresu.": "Na „{email}” jsme vám poslali odkaz na ověření e-mailové adresy. Kliknutím na odkaz potvrdíte svoji emailovou adresu.",
-  "Nahrát": "Nahrát",
-  "Nahrávejte, mapujte, dobývejte": "Nahrávejte, mapujte, dobývejte",
-  "Nahrávka nenalezena": "Nahrávka nenalezena",
-  "Nahrávka není dostupná": "Nahrávka není dostupná",
-  "Nahrávka neobsahuje žádné GPS body.": "Nahrávka neobsahuje žádné GPS body.",
-  "Nahrává se…": "Nahrává se…",
-  "Nahrávání pozastaveno – klepněte pro obnovení": "Nahrávání pozastaveno – klepněte pro obnovení",
-  "Nastavení": "Nastavení",
-  "Nastavení mapy": "Nastavení mapy",
-  "Nastavit": "Nastavit",
-  "Nastavte si heslo": "Nastavte si heslo",
-  "Ne": "Ne",
-  "Nebo": "Nebo",
-  "Neodeslané části": "Neodeslané části",
-  "Notification": "Notification",
-  "Nová": "Nová",
-  "Nyní se můžete přihlásit do vašeho účtu.": "Nyní se můžete přihlásit do vašeho účtu.",
-  "Název nahrávky": "Název nahrávky",
-  "Nářečí českých strnadů": "Nářečí českých strnadů",
-  "Některé části nahrávky nebyly odeslány. Chcete je zkusit znovu odeslat?": "Některé části nahrávky nebyly odeslány. Chcete je zkusit znovu odeslat?",
-  "OK": "OK",
-  "Obec": "Obec",
-  "Odeslat znovu": "Odeslat znovu",
-  "Odeslat záznam": "Odeslat záznam",
-  "Odhlásit se": "Odhlásit se",
-  "Offline režim": "Offline režim",
-  "Ok": "Ok",
-  "OpenStreetMap in Flutter": "OpenStreetMap in Flutter",
-  "Opravdu chcete opustit nahrávání?": "Opravdu chcete opustit nahrávání?",
-  "Opravdu chcete smazat nahrávku?": "Opravdu chcete smazat nahrávku?",
-  "Opravdu chcete tento záznam natrvalo smazat?": "Opravdu chcete tento záznam natrvalo smazat?",
-  "Opravdu chcete uložit tuto nahrávku?": "Opravdu chcete uložit tuto nahrávku?",
-  "Opravdu se chcete odhlásit?": "Opravdu se chcete odhlásit?",
-  "Opravdu si přejete smazat svůj účet? Tato akce je nevratná.": "Opravdu si přejete smazat svůj účet? Tato akce je nevratná.",
-  "Opustit nahrávání": "Opustit nahrávání",
-  "Osobní údaje": "Osobní údaje",
-  "Osobní údaje nejsou dostupné bez připojení k internetu": "Osobní údaje nejsou dostupné bez připojení k internetu",
-  "Otevřít e-mail": "Otevřít e-mail",
-  "Ověřte svůj e-mail": "Ověřte svůj e-mail",
-  "Oznámení": "Oznámení",
-  "PSČ": "PSČ",
-  "Pokračovat": "Pokračovat",
-  "Pokračovat přes Google": "Pokračovat přes Google",
-  "Pokud neuvedete přezdívku, ostatní uživatelé uvidí vaše skutečné jméno.": "Pokud neuvedete přezdívku, ostatní uživatelé uvidí vaše skutečné jméno.",
-  "Poslat odkaz": "Poslat odkaz",
-  "Potvrdit": "Potvrdit",
-  "Potvrdit smazání": "Potvrdit smazání",
-  "Potvrzení": "Potvrzení",
-  "Pouze já": "Pouze já",
-  "Použít mobilní data pro nahrávání": "Použít mobilní data pro nahrávání",
-  "Počet ptáků": "Počet ptáků",
-  "Počet strnadů": "Počet strnadů",
-  "Predpokladany pocet strnadu: ": "Predpokladany pocet strnadu: ",
-  "Pro pokračování musíte souhlasit s podmínkami.": "Pro pokračování musíte souhlasit s podmínkami.",
-  "Pro pokračování se přihlášením ověřte prosím svůj e-mail ({email}).\\nNa tuto adresu byl zaslán ověřovací odkaz. Klikněte na odkaz pro potvrzení.": "Pro pokračování se přihlášením ověřte prosím svůj e-mail ({email}).\\nNa tuto adresu byl zaslán ověřovací odkaz. Klikněte na odkaz pro potvrzení.",
-  "Pro stažení nahrávky je vyžadováno připojení k internetu.": "Pro stažení nahrávky je vyžadováno připojení k internetu.",
-  "Profile picture upload failed": "Profile picture upload failed",
-  "Profile picture uploaded": "Profile picture uploaded",
-  "Profilové údaje": "Profilové údaje",
-  "Projekt občanské vědy zaměřený na studium rozmanitosti ptačího zpěvu. Nahráváním zpěvu strnadů obecných po celém Česku můžete přispět k poznání, jak se v krajině udržují ptačí nářečí.": "Projekt občanské vědy zaměřený na studium rozmanitosti ptačího zpěvu. Nahráváním zpěvu strnadů obecných po celém Česku můžete přispět k poznání, jak se v krajině udržují ptačí nářečí.",
-  "Právě jsme odeslali e-mail na {email}.\\nDoručení může trvat až 10 minut.\\n\\nPokud brzy neobdržíte pokyny, zkontrolujte složku se spamem nebo nevyžádanou poštou.\\n\\nPokud ani to nepomůže, zkuste odeslat žádost znovu.": "Právě jsme odeslali e-mail na {email}.\\nDoručení může trvat až 10 minut.\\n\\nPokud brzy neobdržíte pokyny, zkontrolujte složku se spamem nebo nevyžádanou poštou.\\n\\nPokud ani to nepomůže, zkuste odeslat žádost znovu.",
-  "Přehled informací": "Přehled informací",
-  "Přezdívka (volitelné)": "Přezdívka (volitelné)",
-  "Přidat dialekt": "Přidat dialekt",
-  "Přidání dialektu": "Přidání dialektu",
-  "Přihlásit se": "Přihlásit se",
-  "Přihlášení": "Přihlášení",
-  "Příjmení *": "Příjmení *",
-  "Recorder": "Recorder",
-  "Register": "Register",
-  "Registrace": "Registrace",
-  "Registrovat": "Registrovat",
-  "Reset hesla": "Reset hesla",
-  "Resetovat": "Resetovat",
-  "Skrýt": "Skrýt",
-  "Smazat": "Smazat",
-  "Smazat nahrávku": "Smazat nahrávku",
-  "Smazat z cache": "Smazat z cache",
-  "Smazat záznam": "Smazat záznam",
-  "Smazání účtu": "Smazání účtu",
-  "Souhlasím se zasíláním marketingových sdělení": "Souhlasím se zasíláním marketingových sdělení",
-  "Stahování nedostupné": "Stahování nedostupné",
-  "Stažené": "Stažené",
-  "Stisknutím zahájíte nahrávání": "Stisknutím zahájíte nahrávání",
-  "Stop": "Stop",
-  "Strnadi": "Strnadi",
-  "Stáhnout nahrávku": "Stáhnout nahrávku",
-  "Submit": "Submit",
-  "Tento e-mail již byl ověřen.": "Tento e-mail již byl ověřen.",
-  "Time:": "Time:",
-  "Třídit podle data": "Třídit podle data",
-  "Třídit podle názvu": "Třídit podle názvu",
-  "Třídění a filtry": "Třídění a filtry",
-  "Uložit": "Uložit",
-  "Uložit změny": "Uložit změny",
-  "Update": "Update",
-  "Update Available": "Update Available",
-  "Upravit záznam": "Upravit záznam",
-  "Uživatel již existuje": "Uživatel již existuje",
-  "Uživatel s tímto e-mailem již existuje.": "Uživatel s tímto e-mailem již existuje.",
-  "Vyberte fotografie": "Vyberte fotografie",
-  "Vyfotit": "Vyfotit",
-  "Všichni": "Všichni",
-  "Zadejte vaše jméno, příjmení\\na zvolte si přezdívku": "Zadejte vaše jméno, příjmení\\na zvolte si přezdívku",
-  "Zadejte váš e-mail": "Zadejte váš e-mail",
-  "Zadejte váš e-mail pro změnu hesla": "Zadejte váš e-mail pro změnu hesla",
-  "Zahodit nahrávání": "Zahodit nahrávání",
-  "Založit účet": "Založit účet",
-  "Zapomenuté heslo?": "Zapomenuté heslo?",
-  "Zatím nemáte žádné záznamy": "Zatím nemáte žádné záznamy",
-  "Zavřít": "Zavřít",
-  "Zkontrolujte prosím zadané údaje a potvrďte registraci.": "Zkontrolujte prosím zadané údaje a potvrďte registraci.",
-  "Změna hesla": "Změna hesla",
-  "Zobrazení mapy:": "Zobrazení mapy:",
-  "Zobrazit": "Zobrazit",
-  "Zobrazovat i nepotvrzené dialekty:": "Zobrazovat i nepotvrzené dialekty:",
-  "Zoom:": "Zoom:",
-  "Zopakujte heslo *": "Zopakujte heslo *",
-  "Zpět": "Zpět",
-  "Zpět k nahrávání": "Zpět k nahrávání",
-  "Zrušit": "Zrušit",
-  "Zrušit filtr": "Zrušit filtr",
-  "current possition initialized": "current possition initialized",
-  "ochrany osobních údajů.": "ochrany osobních údajů.",
-  "pokračováním souhlasíte se zásadami": "pokračováním souhlasíte se zásadami",
-  "vybrané": "vybrané",
-  "• Alespoň 8 znaků": "• Alespoň 8 znaků",
-  "• Alespoň jedna číslice (0–9)": "• Alespoň jedna číslice (0–9)",
-  "• Alespoň jedno malé písmeno": "• Alespoň jedno malé písmeno",
-  "• Alespoň jedno velké písmeno": "• Alespoň jedno velké písmeno"
+  "auth": {
+    "title": "Nářečí českých strnadů",
+    "subtitle": "Nahrávejte, mapujte, dobývejte",
+    "buttons": {
+      "register": "Založit účet",
+      "login": "Přihlásit se",
+      "ok": "OK"
+    },
+    "alerts": {
+      "offline_no_token": {
+        "title": "Offline",
+        "message": "Nemáte připojení k internetu a žádný token není uložen."
+      },
+      "offline_expired_token": {
+        "title": "Offline",
+        "message": "Váš JWT vypršel. Prosím připojte se k internetu pro obnovení."
+      },
+      "offline_not_verified": {
+        "title": "Offline",
+        "message": "Váš účet není ověřen. Prosím ověřte svůj email pro další přístup."
+      },
+      "offline_action_blocked": {
+        "title": "Offline",
+        "message": "Tato akce není dostupná offline."
+      },
+      "logged_out": "Byli jste odhlášeni"
+    },
+    "disclaimer": {
+      "consent_prefix": "pokračováním souhlasíte se zásadami",
+      "privacy_policy": "ochrany osobních údajů.",
+      "dev_notice": "Aplikace i web stále procházejí velmi bouřlivým vývojem. Za chyby se omlouváme. Těšte se na časté aktualizace a vylepšování."
+    },
+    "terms": {
+      "title": "Podmínky používání",
+      "path": "assets/docs/terms-of-services.md"
+    }
+  },
+  "login": {
+    "title": "Přihlášení",
+    "inputs": {
+      "emailLabel": "E-mail",
+      "passwordLabel": "Heslo"
+    },
+    "or": "Nebo",
+    "buttons": {
+      "loginButton": "Přihlásit se",
+      "forgotPassword": "Zapomenuté heslo?",
+      "googleSignIn": "Pokračovat přes Google"
+    },
+    "errors": {
+      "emptyFieldsError": "Vyplňte jméno i heslo",
+      "wrongCredentialsError": "Špatné jméno nebo heslo",
+      "loginFailedError": "Přihlášení selhalo, zkuste to znovu",
+      "connectionError": "Chyba připojení"
+    }
+  },
+  "signup": {
+    "mail": {
+      "title": "Zadejte váš e-mail",
+      "mail": "E-mail",
+      "or": "Nebo",
+      "ok": "OK",
+      "buttons": {
+        "continue": "Pokračovat",
+        "con_google": "Pokračovat přes Google"
+      },
+      "consent": {
+        "con1": "Zapojením do projektu občanské vědy Nářečí českých strnadů ",
+        "con2": "souhlasím s podmínkami"
+      },
+      "errors": {
+        "user_exists": {
+          "title": "Uživatel již existuje",
+          "content": "Uživatel s tímto e-mailem již existuje."
+        },
+        "mail_format_err": "Email není v platném formátu",
+        "mail_exists": "Email již existuje",
+        "google_login_failed": "Přihlášení přes Google selhalo",
+        "continue_consent": "Pro pokračování musíte souhlasit s podmínkami."
+      }
+    },
+    "password": {
+      "title": "Nastavte si heslo",
+      "password": "Heslo *",
+      "repeat_password": "Zopakujte heslo *",
+      "password_hint": "Zadejte heslo",
+      "password_again_hint": "Zopakujte heslo",
+      "password_req": {
+        "capital_letter": "• Alespoň jedno velké písmeno",
+        "lovercase_letter": "• Alespoň jedno malé písmeno",
+        "digit": "• Alespoň jedna číslice (0–9)",
+        "lenght_req": "• Alespoň 8 znaků"
+      },
+      "buttons": {
+        "continue": "Pokračovat"
+      },
+      "errors": {
+        "req_not_met": "Heslo nesplňuje požadavky",
+        "password_match_err": "Zopakujte heslo"
+      }
+    },
+    "name": {
+      "title": "Zadejte vaše jméno, příjmení\na zvolte si přezdívku",
+      "name": "Jméno *",
+      "last_name": "Příjmení *",
+      "nickname": "Přezdívka (volitelné)",
+      "nickname_hint": "Volitelné",
+      "real_name_warning": "Pokud neuvedete přezdívku, ostatní uživatelé uvidí vaše skutečné jméno.",
+      "continue": "Pokračovat",
+      "errors": {
+        "null_name_err": "Zadejte jméno",
+        "null_last_name_err": "Zadejte příjmení"
+      }
+    },
+    "city": {
+      "title": "Kde se nacházíte?",
+      "subtitle": "Abychom vás mohli informovat ohledně zajímavostí z vaší lokality, budeme potřebovat vaše PSČ (použito pro cílení notifikací) a obec (město, které se zobrazí ostatním uživatelům). Tento krok je nepovinný.",
+      "post_code": "PSČ",
+      "city": "Obec",
+      "continue": "Pokračovat",
+      "errors": {
+        "user_exists": "Uživatel již existuje",
+        "error_ocured": "Nastala chyba :( Zkuste to znovu"
+      }
+    },
+    "overview": {
+      "title": "Přehled informací",
+      "subtitle": "Přehled informací",
+      "marketing_consent": "Souhlasím se zasíláním marketingových sdělení",
+      "buttons": {
+        "register": "Registrovat"
+      },
+      "errors": {
+        "user_exists": "Uživatel již existuje",
+        "error_ocured": "Nastala chyba :( Zkuste to znovu"
+      }
+    }
+  },
+  "dialectBadge": {
+    "title": "Dialekt"
+  },
+  "editRecording": {
+    "title": "Upravit záznam",
+    "fields": {
+      "name": "Název",
+      "note": "Poznámka",
+      "count": "Počet strnadů",
+      "device": "Zařízení"
+    },
+    "buttons": {
+      "saveChanges": "Uložit změny"
+    }
+  },
+  "bottomBar": {
+    "errors": {
+      "noInternetMap": "Chybí připojení k internetu. Mapa není dostupná."
+    }
+  },
+  "dialogs": {
+    "message": "Zpráva"
+  },
+  "recList": {
+    "title": "Moje nahrávky",
+    "offlineMode": {
+      "title": "Offline režim",
+      "message": "Jste offline. Budou dostupné pouze lokálně uložené záznamy."
+    },
+    "buttons": {
+      "ok": "OK",
+      "sortAndFilter": "Třídění a filtry",
+      "sortByName": "Třídit podle názvu",
+      "sortByDate": "Třídit podle data",
+      "sortByBirdCount": "Počet ptáků",
+      "filterDownloaded": "Stažené",
+      "clearFilter": "Zrušit filtr"
+    },
+    "emptyListMessage": "Zatím nemáte žádné záznamy",
+    "status": {
+      "sending": "Odesílání...",
+      "checkingParts": "Kontrola částí...",
+      "unsentParts": "Neodeslané části",
+      "uploaded": "Nahráno",
+      "waitingForUpload": "Čeká na nahrání"
+    },
+    "dialect": {
+      "loading": "Načítání dialektu...",
+      "unknown": "Neznámý dialekt"
+    },
+    "name": {
+      "loading": "Načítání...",
+      "unknown": "Neznámý název"
+    }
+  },
+  "recListItem": {
+    "status": {
+      "sending": "Odesílání...",
+      "checkingParts": "Kontrola částí...",
+      "unsentParts": "Neodeslané části",
+      "uploaded": "Nahráno",
+      "waitingForUpload": "Čeká na nahrání"
+    },
+    "errors": {
+      "reverseGeocodeFailed": "Reverse geocode selhalo",
+      "errorDownloading": "Chyba při stahování nahrávky",
+      "errorDeleting": "Chyba při mazání nahrávky"
+    },
+    "buttons": {
+      "download": "Stáhnout nahrávku",
+      "delete": "Smazat záznam",
+      "resendUnsentParts": "Odeslat znovu",
+      "send": "Odeslat záznam",
+      "deleteCache": "Smazat z cache"
+    },
+    "dialogs": {
+      "confirmDelete": {
+        "title": "Potvrdit smazání",
+        "message": "Opravdu chcete tento záznam natrvalo smazat?",
+        "cancel": "Zrušit",
+        "delete": "Smazat"
+      },
+      "unsentParts": {
+        "title": "Neodeslané části",
+        "message": "Některé části nahrávky nebyly odeslány. Chcete je zkusit znovu odeslat?",
+        "cancel": "Zrušit",
+        "resend": "Odeslat znovu"
+      },
+      "downloadUnavailable": {
+        "title": "Stahování nedostupné",
+        "message": "Pro stažení nahrávky je vyžadováno připojení k internetu."
+      }
+    },
+    "placeTitle": "Mapa",
+    "noRecording": "Nahrávka není dostupná",
+    "notePlaceholder": "K tomuto záznamu není poznámka",
+    "dateTime": "Datum a čas",
+    "estimatedBirdsCount": "Předpokládaný počet strnadů"
+  },
+  "user_badge": {
+    "no_nickname": "Uzivatel nema prezdivku"
+  },
+  "map": {
+    "notifications": {
+      "enableLocation": "Please enable location services",
+      "locationDenied": "Location permissions are denied",
+      "locationDeniedForever": "Location permissions are permanently denied",
+      "locationError": "Error retrieving location"
+    },
+    "dialogs": {
+      "notification": {
+        "title": "Notification",
+        "ok": "OK"
+      },
+      "error": {
+        "title": "Chyba",
+        "close": "Zavřít"
+      },
+      "confirmDelete": {
+        "title": "Potvrdit smazání",
+        "message": "Opravdu chcete tento záznam natrvalo smazat?",
+        "cancel": "Zrušit",
+        "delete": "Smazat"
+      }
+    },
+    "buttons": {
+      "info": "Info",
+      "mapSettings": "Map Settings",
+      "reset": "Reset orientation & recenter",
+      "close": "Zavřít",
+      "set": "Nastavit",
+      "resetFilters": "Resetovat"
+    },
+    "filters": {
+      "mapView": {
+        "classic": "Klasické",
+        "satellite": "Letecké"
+      },
+      "recordingAuthor": {
+        "all": "Všichni",
+        "me": "Pouze já"
+      }
+    },
+    "legend": {
+      "title": "Legenda",
+      "dialects": {
+        "BC": "BC",
+        "BE": "BE",
+        "BlBh": "BlBh",
+        "BhBl": "BhBl",
+        "XB": "XB",
+        "rare": "Vzácné",
+        "transitional": "Přechodný",
+        "mix": "Mix",
+        "atypical": "Atypický",
+        "unfinished": "Nedokončený",
+        "unassessed": "Nevyhodnoceno",
+        "unusable": "Nepoužitelný"
+      },
+      "mapyCz": "Mapy.cz © Seznam.cz, a.s."
+    }
+  },
+  "recordingPage": {
+    "status": {
+      "loading": "Nahrávka není dostupná",
+      "downloading": "Stáhnout nahrávku",
+      "errorDownloading": "Error downloading recording"
+    },
+    "audioPlayer": {
+      "replay": "Přetočit 10s zpět",
+      "play": "Přehrát",
+      "pause": "Pozastavit",
+      "forward": "Přetočit 10s vpřed"
+    },
+    "note": {
+      "placeholder": "K tomuto záznamu není poznámka"
+    },
+    "dateTime": "Datum a čas",
+    "estimatedBirdsCount": "Předpokládaný počet strnadů",
+    "map": {
+      "title": "Mapa"
+    }
+  },
+  "postRecordingForm": {
+    "addDialect": {
+      "title": "Přidání dialektu",
+      "confirm": "Potvrdit",
+      "options": {
+        "BC": "BC",
+        "BE": "BE",
+        "BlBh": "BlBh",
+        "BhBl": "BhBl",
+        "XB": "XB",
+        "other": "Jiné",
+        "noDialect": "Bez Dialektu",
+        "unknown": "Nevím"
+      },
+      "dialogs": {
+        "confirmation": {
+          "title": "Potvrzení",
+          "message": "Opravdu chcete smazat nahrávku?",
+          "yes": "Ano",
+          "no": "Ne"
+        }
+      }
+    },
+    "imageUpload": {
+      "title": "Fotografie",
+      "selectedCount": "{count} vybrané",
+      "buttons": {
+        "takePhoto": "Vyfotit",
+        "upload": "Nahrát"
+      },
+      "placeholders": {
+        "noImages": "Vyberte fotografie"
+      }
+    },
+    "recordingForm": {
+      "fields": {
+        "recordingName": "Název nahrávky",
+        "comment": "Komentář",
+        "birdCount": "Počet strnadů",
+        "map": "Mapa"
+      },
+      "buttons": {
+        "addDialect": "Přidat dialekt",
+        "save": "Uložit",
+        "discard": "Smazat nahrávku"
+      },
+      "dialogs": {
+        "confirmation": {
+          "title": "Potvrzení",
+          "message": "Opravdu chcete uložit tuto nahrávku?",
+          "yes": "Ano",
+          "no": "Ne"
+        },
+        "discard": {
+          "title": "Potvrzení",
+          "message": "Opravdu chcete smazat nahrávku?",
+          "yes": "Ano",
+          "no": "Ne"
+        }
+      },
+      "placeholders": {
+        "noGpsPoints": "Nahrávka neobsahuje žádné GPS body.",
+        "noInternet": "Mapu nelze načíst bez připojení k internetu."
+      },
+      "slider": {
+        "oneBird": "1 strnad",
+        "twoBirds": "2 strnadi",
+        "threeOrMoreBirds": "3 a více strnadů"
+      }
+    }
+  },
+  "streamRec": {
+    "dialogs": {
+      "info": {
+        "title": "Informace",
+        "ok": "OK"
+      },
+      "confirmExit": {
+        "title": "Potvrdit",
+        "message": "Opravdu chcete opustit nahrávání?",
+        "cancel": "Zpět k nahrávání",
+        "confirm": "Opustit nahrávání"
+      }
+    },
+    "errors": {
+      "micPermission": "Pro správné fungování aplikace je potřeba povolit mikrofon",
+      "locationPermission": "Pro zahájení nahrávání musíte povolit přístup k poloze",
+      "noRecordingFound": "Nenalezena žádná nahrávka k uložení",
+      "concatError": "Chyba při spojování souborů",
+      "locationFetchError": "Chyba při získávání polohy"
+    },
+    "notifications": {
+      "recordingInProgress": "Aplikace Strnadi nahrává",
+      "recordingPaused": "Nahrávání pozastaveno"
+    },
+    "buttons": {
+      "startRecording": "Start recording",
+      "pauseRecording": "Pause recording",
+      "resumeRecording": "Resume recording",
+      "finishRecording": "Dokončit a pokračovat",
+      "discardRecording": "Zahodit nahrávání"
+    },
+    "status": {
+      "recording": "Nahrává se…",
+      "paused": "Nahrávání pozastaveno – klepněte pro obnovení",
+      "stopped": "Stisknutím zahájíte nahrávání"
+    },
+    "timer": {
+      "format": "{minutes}:{seconds},{hundredths}"
+    }
+  },
+  "user": {
+    "profile": {
+      "title": "Osobní údaje",
+      "fields": {
+        "firstName": "Jméno",
+        "lastName": "Příjmení",
+        "nickname": "Přezdívka",
+        "postCode": "PSČ",
+        "city": "Obec"
+      },
+      "buttons": {
+        "save": "Uložit",
+        "deleteAccount": "Chci si smazat účet",
+        "changePassword": "Změna hesla"
+      },
+      "dialogs": {
+        "deleteAccount": {
+          "title": "Smazání účtu",
+          "message": "Opravdu si přejete smazat svůj účet? Tato akce je nevratná.",
+          "cancel": "Zrušit",
+          "confirm": "Smazat"
+        },
+        "error": {
+          "title": "Chyba",
+          "message": "Nepodařilo se načíst uživatele nebo token"
+        },
+        "success": {
+          "message": "Údaje byly úspěšně aktualizovány"
+        }
+      }
+    },
+    "settings": {
+      "title": "Nastavení",
+      "fields": {
+        "useMobileData": "Použít mobilní data pro nahrávání",
+        "localRecordingsMax": "Maximální počet nahrávek uložených lokálně"
+      },
+      "descriptions": {
+        "localRecordingsMax": "Po dosažení tohoto limitu budou nejstarší nahrávky odstraněny."
+      }
+    },
+    "menu": {
+      "items": {
+        "personalInfo": "Osobní údaje",
+        "settings": "Nastavení",
+        "guide": "Příručka",
+        "aboutProject": "O projektu",
+        "aboutApp": "O aplikaci"
+      },
+      "dialogs": {
+        "aboutApp": {
+          "title": "Strnadi Mobile App",
+          "creators": "Creators: Marian Pecqueur && Jan Drobílek",
+          "contact": "Kontakt: info@strnadi.cz, developers@strnadi.cz"
+        }
+      }
+    },
+    "settingsPages": {
+      "appSettings": {
+        "title": "Nastavení",
+        "fields": {
+          "useMobileData": "Použít mobilní data pro nahrávání",
+          "localRecordingsMax": "Maximální počet nahrávek uložených lokálně"
+        },
+        "descriptions": {
+          "localRecordingsMax": "Po dosažení tohoto limitu budou nejstarší nahrávky odstraněny."
+        }
+      },
+      "userInfo": {
+        "title": "Osobní údaje",
+        "fields": {
+          "firstName": "Jméno",
+          "lastName": "Příjmení",
+          "nickname": "Přezdívka",
+          "postCode": "PSČ",
+          "city": "Obec"
+        },
+        "buttons": {
+          "save": "Uložit",
+          "deleteAccount": "Chci si smazat účet",
+          "changePassword": "Změna hesla"
+        },
+        "dialogs": {
+          "deleteAccount": {
+            "title": "Smazání účtu",
+            "message": "Opravdu si přejete smazat svůj účet? Tato akce je nevratná.",
+            "cancel": "Zrušit",
+            "confirm": "Smazat"
+          },
+          "error": {
+            "title": "Chyba",
+            "message": "Nepodařilo se načíst uživatele nebo token"
+          },
+          "success": {
+            "message": "Údaje byly úspěšně aktualizovány"
+          }
+        }
+      }
+    }
+  }
 }

--- a/lib/PostRecordingForm/RecordingForm.dart
+++ b/lib/PostRecordingForm/RecordingForm.dart
@@ -196,12 +196,12 @@ class _RecordingFormState extends State<RecordingForm> {
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
-          title: Text(t('Message')),
+          title: Text(t('dialogs.message')),
           content: Text(message),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(),
-              child: Text(t('OK')),
+              child: Text(t('auth.buttons.ok')),
             ),
           ],
         );
@@ -214,20 +214,20 @@ class _RecordingFormState extends State<RecordingForm> {
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
-          title: Text(t('Potvrzení')),
-          content: Text(t('Opravdu chcete smazat nahrávku?')),
+          title: Text(t('postRecordingForm.addDialect.dialogs.confirmation.title')),
+          content: Text(t('postRecordingForm.addDialect.dialogs.confirmation.message')),
           actions: [
             TextButton(
               onPressed: () {
                 Navigator.of(context).pop(false);
               },
-              child: Text(t('Ne')),
+              child: Text(t('postRecordingForm.addDialect.dialogs.confirmation.no')),
             ),
             TextButton(
               onPressed: () {
                 Navigator.of(context).pop(true);
               },
-              child: Text(t('Ano')),
+              child: Text(t('postRecordingForm.addDialect.dialogs.confirmation.yes')),
             ),
           ],
         );
@@ -240,14 +240,14 @@ class _RecordingFormState extends State<RecordingForm> {
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
-          title: Text(t('Potvrzení')),
-          content: Text(t('Opravdu chcete smazat nahrávku?')),
+          title: Text(t('postRecordingForm.addDialect.dialogs.confirmation.title')),
+          content: Text(t('postRecordingForm.addDialect.dialogs.confirmation.message')),
           actions: [
             TextButton(
               onPressed: () {
                 Navigator.of(context).pop();
               },
-              child: Text(t('Ne')),
+              child: Text(t('postRecordingForm.addDialect.dialogs.confirmation.no')),
             ),
             TextButton(
               onPressed: () {
@@ -258,7 +258,7 @@ class _RecordingFormState extends State<RecordingForm> {
                   MaterialPageRoute(builder: (context) => LiveRec()),
                 );
               },
-              child: Text(t('Ano')),
+              child: Text(t('postRecordingForm.addDialect.dialogs.confirmation.yes')),
             ),
           ],
         );
@@ -633,16 +633,16 @@ class _RecordingFormState extends State<RecordingForm> {
                     context: context,
                     builder: (BuildContext context) {
                       return AlertDialog(
-                        title: Text(t('Potvrzení')),
-                        content: Text(t('Opravdu chcete uložit tuto nahrávku?')),
+                        title: Text(t('postRecordingForm.addDialect.dialogs.confirmation.title')),
+                        content: Text(t('postRecordingForm.recordingForm.dialogs.confirmation.message')),
                         actions: [
                           TextButton(
                             onPressed: () => Navigator.of(context).pop(false),
-                            child: Text(t('Ne')),
+                            child: Text(t('postRecordingForm.addDialect.dialogs.confirmation.no')),
                           ),
                           TextButton(
                             onPressed: () => Navigator.of(context).pop(true),
-                            child: Text(t('Ano')),
+                            child: Text(t('postRecordingForm.addDialect.dialogs.confirmation.yes')),
                           ),
                         ],
                       );
@@ -660,7 +660,7 @@ class _RecordingFormState extends State<RecordingForm> {
                   shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
                   padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
                 ),
-                child: Text(t("Uložit")),
+                child: Text(t('postRecordingForm.recordingForm.buttons.save')),
               ),
             ),
           ],
@@ -707,7 +707,7 @@ class _RecordingFormState extends State<RecordingForm> {
                   padding: const EdgeInsets.symmetric(vertical: 16.0),
                   child: ElevatedButton.icon(
                     icon: const Icon(Icons.add),
-                    label: Text(t('Přidat dialekt')),
+                    label: Text(t('postRecordingForm.recordingForm.buttons.addDialect')),
                     style: ElevatedButton.styleFrom(
                       backgroundColor: const Color(0xFFFFF7C0),
                       foregroundColor: Colors.black,
@@ -733,7 +733,7 @@ class _RecordingFormState extends State<RecordingForm> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         // Název nahrávky field
-                        Text(t('Název nahrávky'), style: TextStyle(fontWeight: FontWeight.bold)),
+                        Text(t('postRecordingForm.recordingForm.fields.recordingName'), style: TextStyle(fontWeight: FontWeight.bold)),
                         const SizedBox(height: 5),
                         Container(
                           decoration: BoxDecoration(
@@ -761,7 +761,7 @@ class _RecordingFormState extends State<RecordingForm> {
                         ),
                         const SizedBox(height: 20),
                         // Počet strnadů slider
-                        Text(t('Počet strnadů'), style: TextStyle(fontWeight: FontWeight.bold)),
+                        Text(t('editRecording.fields.count'), style: TextStyle(fontWeight: FontWeight.bold)),
                         const SizedBox(height: 5),
                         // Display current slider value above the slider.
                         Text(
@@ -788,7 +788,7 @@ class _RecordingFormState extends State<RecordingForm> {
                         ),
                         const SizedBox(height: 20),
                         // Komentář field (multiline)
-                        Text(t('Komentář'), style: TextStyle(fontWeight: FontWeight.bold)),
+                        Text(t('postRecordingForm.recordingForm.fields.comment'), style: TextStyle(fontWeight: FontWeight.bold)),
                         const SizedBox(height: 5),
                         Container(
                           decoration: BoxDecoration(
@@ -811,7 +811,7 @@ class _RecordingFormState extends State<RecordingForm> {
                         ),
                         const SizedBox(height: 20),
                         // Mapa label and map widget with same padding as text fields.
-                        Text(t('Mapa'), style: TextStyle(fontWeight: FontWeight.bold)),
+                        Text(t('recListItem.placeTitle'), style: TextStyle(fontWeight: FontWeight.bold)),
                         const SizedBox(height: 5),
                         Padding(
                           padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 12),
@@ -828,7 +828,7 @@ class _RecordingFormState extends State<RecordingForm> {
                                     return Container(
                                       color: Colors.grey.shade300,
                                       alignment: Alignment.center,
-                                      child: Text(t("Mapu nelze načíst bez připojení k internetu."),
+                                      child: Text(t('postRecordingForm.recordingForm.placeholders.noInternet'),
                                         style: TextStyle(fontSize: 14, color: Colors.black54),
                                       ),
                                     );
@@ -871,7 +871,7 @@ class _RecordingFormState extends State<RecordingForm> {
                                       Container(
                                         color: Colors.grey.shade300,
                                         alignment: Alignment.center,
-                                        child: Text(t("Nahrávka neobsahuje žádné GPS body."),
+                                        child: Text(t('postRecordingForm.recordingForm.placeholders.noGpsPoints'),
                                           style: TextStyle(fontSize: 14, color: Colors.black54, fontWeight: FontWeight.bold),
                                         ),
                                       );
@@ -892,14 +892,14 @@ class _RecordingFormState extends State<RecordingForm> {
                                   context: context,
                                   builder: (BuildContext context) {
                                     return AlertDialog(
-                                      title: Text(t('Potvrzení')),
-                                      content: Text(t('Opravdu chcete smazat nahrávku?')),
+                                      title: Text(t('postRecordingForm.addDialect.dialogs.confirmation.title')),
+                                      content: Text(t('postRecordingForm.addDialect.dialogs.confirmation.message')),
                                       actions: [
                                         TextButton(
                                           onPressed: () {
                                             Navigator.of(context).pop();
                                           },
-                                          child: Text(t('Ne')),
+                                          child: Text(t('postRecordingForm.addDialect.dialogs.confirmation.no')),
                                         ),
                                         TextButton(
                                           onPressed: () {
@@ -910,7 +910,7 @@ class _RecordingFormState extends State<RecordingForm> {
                                               MaterialPageRoute(builder: (context) => LiveRec()),
                                             );
                                           },
-                                          child: Text(t('Ano')),
+                                          child: Text(t('postRecordingForm.addDialect.dialogs.confirmation.yes')),
                                         ),
                                       ],
                                     );
@@ -924,7 +924,7 @@ class _RecordingFormState extends State<RecordingForm> {
                                 shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
                                 padding: const EdgeInsets.symmetric(vertical: 12),
                               ),
-                              child: Text(t('Smazat nahrávku')),
+                              child: Text(t('postRecordingForm.recordingForm.buttons.discard')),
                             ),
                           ),
                         ),

--- a/lib/PostRecordingForm/addDialect.dart
+++ b/lib/PostRecordingForm/addDialect.dart
@@ -113,7 +113,7 @@ class _DialectSelectionDialogState extends State<DialectSelectionDialog> {
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      Text(t('Přidání dialektu'),
+                      Text(t('postRecordingForm.addDialect.title'),
                         textAlign: TextAlign.center,
                         style: TextStyle(
                           fontSize: 18,
@@ -208,7 +208,7 @@ class _DialectSelectionDialogState extends State<DialectSelectionDialog> {
                           Navigator.pop(context);
                         }
                             : null,
-                        child: Text(t('Potvrdit')),
+                        child: Text(t('postRecordingForm.addDialect.confirm')),
                       ),
                     ],
                   ),

--- a/lib/PostRecordingForm/imageUpload.dart
+++ b/lib/PostRecordingForm/imageUpload.dart
@@ -77,13 +77,15 @@ class _MultiPhotoUploadWidgetState extends State<MultiPhotoUploadWidget> {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Text(t('Fotografie'),
+            Text(t('postRecordingForm.imageUpload.title'),
               style: TextStyle(
                 fontSize: 16,
                 fontWeight: FontWeight.bold,
               ),
             ),
-            Text('${_images.length} ${t('vybrané')}',
+            Text(
+              t('postRecordingForm.imageUpload.selectedCount')
+                  .replaceFirst('{count}', _images.length.toString()),
               style: TextStyle(
                 color: Colors.grey[600],
               ),
@@ -100,7 +102,7 @@ class _MultiPhotoUploadWidgetState extends State<MultiPhotoUploadWidget> {
               child: ElevatedButton.icon(
                 onPressed: () => _pickImage(ImageSource.camera),
                 icon: const Icon(Icons.camera_alt, size: 16),
-                label: Text(t('Vyfotit'), style: TextStyle(fontSize: 14)),
+                label: Text(t('postRecordingForm.imageUpload.buttons.takePhoto'), style: TextStyle(fontSize: 14)),
                 style: ElevatedButton.styleFrom(
                   padding: const EdgeInsets.symmetric(vertical: 12),
                   shape: RoundedRectangleBorder(
@@ -114,7 +116,7 @@ class _MultiPhotoUploadWidgetState extends State<MultiPhotoUploadWidget> {
               child: ElevatedButton.icon(
                 onPressed: _pickMultipleImages,
                 icon: const Icon(Icons.photo_library, size: 16),
-                label: Text(t('Nahrát'), style: TextStyle(fontSize: 14)),
+                label: Text(t('postRecordingForm.imageUpload.buttons.upload'), style: TextStyle(fontSize: 14)),
                 style: ElevatedButton.styleFrom(
                   padding: const EdgeInsets.symmetric(vertical: 12),
                   shape: RoundedRectangleBorder(
@@ -185,7 +187,7 @@ class _MultiPhotoUploadWidgetState extends State<MultiPhotoUploadWidget> {
               border: Border.all(color: Colors.grey.shade300),
               borderRadius: BorderRadius.circular(8),
             ),
-            child: Text(t('Vyberte fotografie'),
+            child: Text(t('postRecordingForm.imageUpload.placeholders.noImages'),
               style: TextStyle(
                 color: Colors.grey[600],
                 fontSize: 14,

--- a/lib/archived/login.dart
+++ b/lib/archived/login.dart
@@ -99,7 +99,7 @@ class _LoginState extends State<Login> {
       context: context,
       builder: (context) => AlertDialog(
         content: Text(message),
-        actions: [TextButton(onPressed: () => Navigator.pop(context), child: Text(t('OK')))],
+        actions: [TextButton(onPressed: () => Navigator.pop(context), child: Text(t('auth.buttons.ok')))],
       ),
     );
   }
@@ -152,7 +152,7 @@ class _LoginState extends State<Login> {
                 onTap: () {
                   Navigator.push(context, MaterialPageRoute(builder: (_) => const ForgottenPassword()));
                 },
-                child: Text(t('Zapomenuté heslo?'),
+                child: Text(t('login.buttons.forgotPassword'),
                   style: TextStyle(color: Colors.grey),
                 ),
               ),
@@ -165,7 +165,7 @@ class _LoginState extends State<Login> {
                 shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
               ),
               onPressed: login,
-              child: Text(t('Přihlásit se')),
+              child: Text(t('auth.buttons.login')),
             ),
             const SizedBox(height: 16),
             Center(

--- a/lib/archived/map.dart
+++ b/lib/archived/map.dart
@@ -34,7 +34,7 @@ void _showMessage(String message) {
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
-          child: Text(t('OK')),
+          child: Text(t('auth.buttons.ok')),
         ),
       ],
     ),
@@ -79,7 +79,7 @@ class _OSMmapState extends State<OSMmap> {
         permission = await Geolocator.requestPermission();
         if (permission == LocationPermission.denied) {
           logger.w("Location permissions are denied");
-          print("Location permissions are denied");
+          print('map.notifications.locationDenied');
           setState(() {
             _currentPosition = LatLng(50.1, 14.4);
           });
@@ -89,7 +89,7 @@ class _OSMmapState extends State<OSMmap> {
 
       if (permission == LocationPermission.deniedForever) {
         logger.w("Location permissions are permanently denied");
-        print("Location permissions are permanently denied");
+        print('map.notifications.locationDeniedForever');
         setState(() {
           _currentPosition = LatLng(50.1, 14.4);
         });

--- a/lib/archived/recorderWithSpectogram.dart
+++ b/lib/archived/recorderWithSpectogram.dart
@@ -44,12 +44,12 @@ void _showMessage(BuildContext context, String message) {
   showDialog(
     context: context,
     builder: (context) => AlertDialog(
-      title: Text(t('Notification')),
+      title: Text(t('map.dialogs.notification.title')),
       content: Text(message),
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
-          child: Text(t('OK')),
+          child: Text(t('auth.buttons.ok')),
         ),
       ],
     ),

--- a/lib/archived/register.dart
+++ b/lib/archived/register.dart
@@ -112,7 +112,7 @@ class _RegisterState extends State<Register> {
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
-            child: Text(t('OK')),
+            child: Text(t('auth.buttons.ok')),
           ),
         ],
       ),

--- a/lib/auth/authorizator.dart
+++ b/lib/auth/authorizator.dart
@@ -193,7 +193,7 @@ class _AuthState extends State<Authorizator> {
                   const SizedBox(height: 32),
 
                   // Main title
-                  Text(t('Nářečí českých strnadů'),
+                  Text(t('auth.title'),
                     textAlign: TextAlign.center,
                     style: TextStyle(
                       fontSize: 24,
@@ -205,7 +205,7 @@ class _AuthState extends State<Authorizator> {
                   const SizedBox(height: 8),
 
                   // Subtitle
-                  Text(t('Nahrávejte, mapujte, dobývejte'),
+                  Text(t('auth.subtitle'),
                     textAlign: TextAlign.center,
                     style: TextStyle(
                       fontSize: 16,
@@ -234,7 +234,7 @@ class _AuthState extends State<Authorizator> {
                           borderRadius: BorderRadius.circular(16),
                         ),
                       ),
-                      child: Text(t('Založit účet'), style: TextStyle(color: textColor),),
+                      child: Text(t('auth.buttons.register'), style: TextStyle(color: textColor),),
                     ),
                   ),
 
@@ -257,7 +257,7 @@ class _AuthState extends State<Authorizator> {
                           borderRadius: BorderRadius.circular(16),
                         ),
                       ),
-                      child: Text(t('Přihlásit se'), style: TextStyle(color: textColor)),
+                      child: Text(t('auth.buttons.login'), style: TextStyle(color: textColor)),
                     ),
                   ),
 
@@ -265,14 +265,14 @@ class _AuthState extends State<Authorizator> {
                   const SizedBox(height: 12),
                   Column(
                     children: [
-                      Text(t('pokračováním souhlasíte se zásadami'),
+                      Text(t('auth.disclaimer.consent_prefix'),
                         textAlign: TextAlign.center,
                         style: TextStyle(fontSize: 12, color: Colors.black),
                       ),
                       const SizedBox(height: 4),
                       GestureDetector(
                         onTap: () => _launchURL(),
-                        child: Text(t('ochrany osobních údajů.'),
+                        child: Text(t('auth.disclaimer.privacy_policy'),
                           textAlign: TextAlign.center,
                           style: TextStyle(
                             fontSize: 12,
@@ -286,7 +286,7 @@ class _AuthState extends State<Authorizator> {
 
                   // Add disclaimer and space at the bottom
                   const SizedBox(height: 60),
-                  Text(t('Aplikace i web stále procházejí velmi bouřlivým vývojem. Za chyby se omlouváme. Těšte se na časté aktualizace a vylepšování.'),
+                  Text(t('auth.disclaimer.dev_notice'),
                     textAlign: TextAlign.center,
                     style: TextStyle(
                       fontSize: 12,
@@ -427,7 +427,7 @@ class _AuthState extends State<Authorizator> {
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
-            child: Text(t('OK')),
+            child: Text(t('auth.buttons.ok')),
           ),
         ],
       ),
@@ -443,7 +443,7 @@ class _AuthState extends State<Authorizator> {
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
-            child: Text(t('OK')),
+            child: Text(t('auth.buttons.ok')),
           ),
         ],
       ),

--- a/lib/auth/launch_warning.dart
+++ b/lib/auth/launch_warning.dart
@@ -60,7 +60,7 @@ class WIP_warning extends StatelessWidget {
               'assets/images/WIP.png',
             ),
             const SizedBox(height: 16),
-            Text(t('Nářečí českých strnadů'),
+            Text(t('auth.title'),
               style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
               textAlign: TextAlign.center,
             ),
@@ -70,7 +70,7 @@ class WIP_warning extends StatelessWidget {
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 16),
-            Text(t('Aplikace i web stále procházejí velmi bouřlivým vývojem. Za chyby se omlouváme. Těšte se na časté aktualizace a vylepšování.'),
+            Text(t('auth.disclaimer.dev_notice'),
               style: TextStyle(
                 color: Colors.red,
                 fontSize: 12,

--- a/lib/auth/login.dart
+++ b/lib/auth/login.dart
@@ -195,7 +195,7 @@ class _LoginState extends State<Login> {
         actions: [
           TextButton(
               onPressed: () => Navigator.pop(context),
-              child: Text(t('OK')))
+              child: Text(t('auth.buttons.ok')))
         ],
       ),
     );
@@ -230,7 +230,7 @@ class _LoginState extends State<Login> {
               const SizedBox(height: 20),
 
               // Title: "Přihlášení"
-              Text(t('Přihlášení'),
+              Text(t('login.title'),
                 style: TextStyle(
                   fontSize: 24,
                   fontWeight: FontWeight.bold,
@@ -244,7 +244,7 @@ class _LoginState extends State<Login> {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     // --- E-mail label and TextField ---
-                    Text(t('E-mail'),
+                    Text(t('login.inputs.emailLabel'),
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w500,
@@ -275,7 +275,7 @@ class _LoginState extends State<Login> {
                     const SizedBox(height: 16),
 
                     // --- Heslo (Password) label and TextField ---
-                    Text(t('Heslo'),
+                    Text(t('login.inputs.passwordLabel'),
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w500,
@@ -335,7 +335,7 @@ class _LoginState extends State<Login> {
                     );
                     // Handle "Forgot password" here
                   },
-                  child: Text(t('Zapomenuté heslo?')),
+                  child: Text(t('login.buttons.forgotPassword')),
                 ),
               ),
 
@@ -352,7 +352,7 @@ class _LoginState extends State<Login> {
                   ),
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 8),
-                    child: Text(t('Nebo')),
+                    child: Text(t('login.or')),
                   ),
                   Expanded(
                     child: Divider(
@@ -391,7 +391,7 @@ class _LoginState extends State<Login> {
                     height: 24,
                     width: 24,
                   ),
-                  label: Text(t('Pokračovat přes Google'),
+                  label: Text(t('login.buttons.googleSignIn'),
                     style: TextStyle(fontSize: 16),
                   ),
                   style: ElevatedButton.styleFrom(
@@ -431,7 +431,7 @@ class _LoginState extends State<Login> {
                 borderRadius: BorderRadius.circular(16.0),
               ),
             ),
-            child: Text(t('Přihlásit se')),
+            child: Text(t('auth.buttons.login')),
           ),
         ),
       ),

--- a/lib/auth/passReset/forgottenPassword.dart
+++ b/lib/auth/passReset/forgottenPassword.dart
@@ -90,7 +90,7 @@ class _ForgottenPasswordState extends State<ForgottenPassword> {
                 const SizedBox(height: 40),
 
                 // Label for Email
-                Text(t('E-mail'),
+                Text(t('login.inputs.emailLabel'),
                   style: TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w500,
@@ -210,7 +210,7 @@ class _ForgottenPasswordState extends State<ForgottenPassword> {
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
-            child: Text(t('OK')),
+            child: Text(t('auth.buttons.ok')),
           ),
         ],
       ),

--- a/lib/auth/passReset/newPassword.dart
+++ b/lib/auth/passReset/newPassword.dart
@@ -128,7 +128,7 @@ class _RegPasswordState extends State<ChangePassword> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   // Title
-                  Text(t('Nastavte si heslo'),
+                  Text(t('signup.password.title'),
                     style: TextStyle(
                       fontSize: 24,
                       fontWeight: FontWeight.bold,
@@ -138,7 +138,7 @@ class _RegPasswordState extends State<ChangePassword> {
                   const SizedBox(height: 24),
 
                   // "Heslo" label
-                  Text(t('Heslo *'),
+                  Text(t('signup.password.password'),
                     style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.w500,
@@ -198,7 +198,7 @@ class _RegPasswordState extends State<ChangePassword> {
                   const SizedBox(height: 16),
 
                   // "Zopakujte heslo" label
-                  Text(t('Zopakujte heslo *'),
+                  Text(t('signup.password.repeat_password'),
                     style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.w500,
@@ -264,19 +264,19 @@ class _RegPasswordState extends State<ChangePassword> {
                   Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(t('• Alespoň jedno velké písmeno'),
+                      Text(t('signup.password.password_req.capital_letter'),
                         style: TextStyle(
                           color: _hasUpper ? Colors.green : textColor,
                           fontSize: 14,
                         ),
                       ),
-                      Text(t('• Alespoň jedno malé písmeno'),
+                      Text(t('signup.password.password_req.lovercase_letter'),
                         style: TextStyle(
                           color: _hasLower ? Colors.green : textColor,
                           fontSize: 14,
                         ),
                       ),
-                      Text(t('• Alespoň jedna číslice (0–9)'),
+                      Text(t('signup.password.password_req.digit'),
                         style: TextStyle(
                           color: _hasDigit ? Colors.green : textColor,
                           fontSize: 14,
@@ -289,7 +289,7 @@ class _RegPasswordState extends State<ChangePassword> {
                       //     fontSize: 14,
                       //   ),
                       // ),
-                      Text(t('• Alespoň 8 znaků'),
+                      Text(t('signup.password.password_req.lenght_req'),
                         style: TextStyle(
                           color: _hasLength ? Colors.green : textColor,
                           fontSize: 14,
@@ -336,7 +336,7 @@ class _RegPasswordState extends State<ChangePassword> {
                           borderRadius: BorderRadius.circular(16.0),
                         ),
                       ),
-                      child: Text(t('Pokračovat')),
+                      child: Text(t('signup.mail.buttons.continue')),
                     ),
                   ),
                 ],

--- a/lib/auth/registeration/cityReg.dart
+++ b/lib/auth/registeration/cityReg.dart
@@ -62,12 +62,12 @@ class _RegLocationState extends State<RegLocation> {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        title: Text(t('Chyba')),
+        title: Text(t('map.dialogs.error.title')),
         content: Text(message),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
-            child: Text(t('OK')),
+            child: Text(t('auth.buttons.ok')),
           ),
         ],
       ),
@@ -173,7 +173,7 @@ class _RegLocationState extends State<RegLocation> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 // Title
-                Text(t('Kde se nacházíte?'),
+                Text(t('signup.city.title'),
                   style: TextStyle(
                     fontSize: 24,
                     fontWeight: FontWeight.bold,
@@ -182,7 +182,7 @@ class _RegLocationState extends State<RegLocation> {
                 ),
                 const SizedBox(height: 8),
                 // Subtitle / Description
-                Text(t('Abychom vás mohli informovat ohledně zajímavostí z vaší lokality, budeme potřebovat vaše PSČ (použito pro cílení notifikací) a obec (město, které se zobrazí ostatním uživatelům). Tento krok je nepovinný.'),
+                Text(t('signup.city.subtitle'),
                   style: TextStyle(
                     fontSize: 14,
                     color: textColor,
@@ -191,7 +191,7 @@ class _RegLocationState extends State<RegLocation> {
                 const SizedBox(height: 32),
 
                 // PSČ label
-                Text(t('PSČ'),
+                Text(t('signup.city.post_code'),
                   style: TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w500,
@@ -225,7 +225,7 @@ class _RegLocationState extends State<RegLocation> {
                 const SizedBox(height: 16),
 
                 // Obec label
-                Text(t('Obec'),
+                Text(t('signup.city.city'),
                   style: TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w500,
@@ -284,7 +284,7 @@ class _RegLocationState extends State<RegLocation> {
                         borderRadius: BorderRadius.circular(16.0),
                       ),
                     ),
-                    child: Text(t('Pokračovat')),
+                    child: Text(t('signup.mail.buttons.continue')),
                   ),
                 ),
               ],

--- a/lib/auth/registeration/emailSent.dart
+++ b/lib/auth/registeration/emailSent.dart
@@ -116,7 +116,7 @@ class _VerifyEmailState extends State<VerifyEmail> {
           actions: [
             TextButton(
               onPressed: alreadyVerified,
-              child: Text(t('OK')),
+              child: Text(t('auth.buttons.ok')),
             ),
           ],
         ));
@@ -279,7 +279,7 @@ class _VerifyEmailState extends State<VerifyEmail> {
                         borderRadius: BorderRadius.circular(16.0),
                       ),
                     ),
-                    child: Text(t('Pokračovat')),
+                    child: Text(t('signup.mail.buttons.continue')),
                   ),
                 ),
                 const SizedBox(height: 16),

--- a/lib/auth/registeration/mail.dart
+++ b/lib/auth/registeration/mail.dart
@@ -56,14 +56,14 @@ class _RegMailState extends State<RegMail> {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        title: Text(t('Uživatel již existuje')),
-        content: Text(t('Uživatel s tímto e-mailem již existuje.')),
+        title: Text(t('signup.mail.errors.user_exists.title')),
+        content: Text(t('signup.mail.errors.user_exists.content')),
         actions: [
           TextButton(
             onPressed: () {
               Navigator.of(context).pop();
             },
-            child: Text(t('OK')),
+            child: Text(t('auth.buttons.ok')),
           ),
         ],
       ),
@@ -120,7 +120,7 @@ class _RegMailState extends State<RegMail> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               // Title
-              Text(t('Zadejte váš e-mail'),
+              Text(t('signup.mail.title'),
                 style: TextStyle(
                   fontSize: 24,
                   fontWeight: FontWeight.bold,
@@ -129,7 +129,7 @@ class _RegMailState extends State<RegMail> {
               const SizedBox(height: 40),
 
               // "E-mail" label
-              Text(t('E-mail'),
+              Text(t('login.inputs.emailLabel'),
                 style: TextStyle(
                   fontSize: 16,
                   fontWeight: FontWeight.w500,
@@ -248,7 +248,7 @@ class _RegMailState extends State<RegMail> {
               if (_termsError)
                 Padding(
                   padding: const EdgeInsets.only(top: 8.0),
-                  child: Text(t('Pro pokračování musíte souhlasit s podmínkami.'),
+                  child: Text(t('signup.mail.errors.continue_consent'),
                     style: TextStyle(color: Colors.red, fontSize: 12),
                   ),
                 ),
@@ -298,7 +298,7 @@ class _RegMailState extends State<RegMail> {
                       borderRadius: BorderRadius.circular(16.0),
                     ),
                   ),
-                  child: Text(t('Pokračovat')),
+                  child: Text(t('signup.mail.buttons.continue')),
                 ),
               ),
 
@@ -316,7 +316,7 @@ class _RegMailState extends State<RegMail> {
                   ),
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 8),
-                    child: Text(t('Nebo')),
+                    child: Text(t('login.or')),
                   ),
                   Expanded(
                     child: Divider(
@@ -370,7 +370,7 @@ class _RegMailState extends State<RegMail> {
                     height: 24,
                     width: 24,
                   ),
-                  label: Text(t('Pokračovat přes Google'),
+                  label: Text(t('login.buttons.googleSignIn'),
                     style: TextStyle(fontSize: 16),
                   ),
                   style: ElevatedButton.styleFrom(

--- a/lib/auth/registeration/nameReg.dart
+++ b/lib/auth/registeration/nameReg.dart
@@ -111,7 +111,7 @@ class _RegNameState extends State<RegName> {
                   const SizedBox(height: 32),
 
                   // "Jméno *" label and text field
-                  Text(t('Jméno *'),
+                  Text(t('signup.name.name'),
                     style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.w500,
@@ -151,7 +151,7 @@ class _RegNameState extends State<RegName> {
                   const SizedBox(height: 16),
 
                   // "Příjmení *" label and text field
-                  Text(t('Příjmení *'),
+                  Text(t('signup.name.last_name'),
                     style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.w500,
@@ -191,7 +191,7 @@ class _RegNameState extends State<RegName> {
                   const SizedBox(height: 16),
 
                   // "Přezdívka" label and text field (optional)
-                  Text(t('Přezdívka (volitelné)'),
+                  Text(t('signup.name.nickname'),
                     style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.w500,
@@ -215,7 +215,7 @@ class _RegNameState extends State<RegName> {
                     ),
                   ),
                   const SizedBox(height: 8),
-                  Text(t('Pokud neuvedete přezdívku, ostatní uživatelé uvidí vaše skutečné jméno.'),
+                  Text(t('signup.name.real_name_warning'),
                     style: TextStyle(
                       fontSize: 12,
                       color: Colors.grey,
@@ -260,7 +260,7 @@ class _RegNameState extends State<RegName> {
                           borderRadius: BorderRadius.circular(16.0),
                         ),
                       ),
-                      child: Text(t('Pokračovat')),
+                      child: Text(t('signup.mail.buttons.continue')),
                     ),
                   ),
                 ],

--- a/lib/auth/registeration/overview.dart
+++ b/lib/auth/registeration/overview.dart
@@ -67,12 +67,12 @@ class _RegOverviewState extends State<RegOverview> {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        title: Text(t('Chyba')),
+        title: Text(t('map.dialogs.error.title')),
         content: Text(message),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
-            child: Text(t('OK')),
+            child: Text(t('auth.buttons.ok')),
           ),
         ],
       ),
@@ -215,7 +215,7 @@ class _RegOverviewState extends State<RegOverview> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(t('Přehled informací'),
+              Text(t('signup.overview.title'),
                 style: TextStyle(
                   fontSize: 24,
                   fontWeight: FontWeight.bold,
@@ -248,7 +248,7 @@ class _RegOverviewState extends State<RegOverview> {
                     },
                   ),
                   Expanded(
-                    child: Text(t('Souhlasím se zasíláním marketingových sdělení'),
+                    child: Text(t('signup.overview.marketing_consent'),
                       style: TextStyle(
                         fontSize: 14,
                         color: _RegOverviewState.textColor,
@@ -276,7 +276,7 @@ class _RegOverviewState extends State<RegOverview> {
                       borderRadius: BorderRadius.circular(16.0),
                     ),
                   ),
-                  child: Text(t('Registrovat')),
+                  child: Text(t('signup.overview.buttons.register')),
                 ),
               ),
             ],

--- a/lib/auth/registeration/passwordReg.dart
+++ b/lib/auth/registeration/passwordReg.dart
@@ -109,7 +109,7 @@ class _RegPasswordState extends State<RegPassword> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 // Title
-                Text(t('Nastavte si heslo'),
+                Text(t('signup.password.title'),
                   style: TextStyle(
                     fontSize: 24,
                     fontWeight: FontWeight.bold,
@@ -119,7 +119,7 @@ class _RegPasswordState extends State<RegPassword> {
                 const SizedBox(height: 24),
 
                 // "Heslo" label
-                Text(t('Heslo *'),
+                Text(t('signup.password.password'),
                   style: TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w500,
@@ -180,7 +180,7 @@ class _RegPasswordState extends State<RegPassword> {
                 const SizedBox(height: 16),
 
                 // "Zopakujte heslo" label
-                Text(t('Zopakujte heslo *'),
+                Text(t('signup.password.repeat_password'),
                   style: TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w500,
@@ -243,19 +243,19 @@ class _RegPasswordState extends State<RegPassword> {
                 Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(t('• Alespoň jedno velké písmeno'),
+                    Text(t('signup.password.password_req.capital_letter'),
                       style: TextStyle(
                         color: _hasUpper ? Colors.green : textColor,
                         fontSize: 14,
                       ),
                     ),
-                    Text(t('• Alespoň jedno malé písmeno'),
+                    Text(t('signup.password.password_req.lovercase_letter'),
                       style: TextStyle(
                         color: _hasLower ? Colors.green : textColor,
                         fontSize: 14,
                       ),
                     ),
-                    Text(t('• Alespoň jedna číslice (0–9)'),
+                    Text(t('signup.password.password_req.digit'),
                       style: TextStyle(
                         color: _hasDigit ? Colors.green : textColor,
                         fontSize: 14,
@@ -268,7 +268,7 @@ class _RegPasswordState extends State<RegPassword> {
                     //     fontSize: 14,
                     //   ),
                     // ),
-                    Text(t('• Alespoň 8 znaků'),
+                    Text(t('signup.password.password_req.lenght_req'),
                       style: TextStyle(
                         color: _hasLength ? Colors.green : textColor,
                         fontSize: 14,
@@ -301,7 +301,7 @@ class _RegPasswordState extends State<RegPassword> {
                         borderRadius: BorderRadius.circular(16.0),
                       ),
                     ),
-                    child: Text(t('Pokračovat')),
+                    child: Text(t('signup.mail.buttons.continue')),
                   ),
                 ),
               ],

--- a/lib/auth/unverifiedEmail.dart
+++ b/lib/auth/unverifiedEmail.dart
@@ -104,7 +104,7 @@ class _EmailNotVerifiedState extends State<EmailNotVerified> {
             actions: [
               TextButton(
                 onPressed: alreadyVerified,
-                child: Text(t('OK')),
+                child: Text(t('auth.buttons.ok')),
               ),
             ],
           ),
@@ -236,7 +236,7 @@ class _EmailNotVerifiedState extends State<EmailNotVerified> {
                       borderRadius: BorderRadius.circular(16.0),
                     ),
                   ),
-                  child: Text(t('Pokračovat')),
+                  child: Text(t('signup.mail.buttons.continue')),
                 ),
               ),
               const SizedBox(height: 16),

--- a/lib/bottomBar.dart
+++ b/lib/bottomBar.dart
@@ -140,7 +140,7 @@ class ReusableBottomAppBar extends StatelessWidget {
               if (!await Config.hasBasicInternet) {
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(
-                    content: Text(t('Chybí připojení k internetu. Mapa není dostupná.')),
+                    content: Text(t('bottomBar.errors.noInternetMap')),
                     duration: Duration(seconds: 3),
                   ),
                 );

--- a/lib/localRecordings/editRecording.dart
+++ b/lib/localRecordings/editRecording.dart
@@ -88,7 +88,7 @@ class _EditRecordingPageState extends State<EditRecordingPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(t('Upravit záznam')),
+        title: Text(t('editRecording.title')),
         actions: [
           IconButton(
             icon: const Icon(Icons.save),
@@ -125,7 +125,7 @@ class _EditRecordingPageState extends State<EditRecordingPage> {
               const SizedBox(height: 20),
               ElevatedButton(
                 onPressed: _save,
-                child: Text(t('Uložit změny')),
+                child: Text(t('editRecording.buttons.saveChanges')),
               ),
             ],
           ),

--- a/lib/localRecordings/recList.dart
+++ b/lib/localRecordings/recList.dart
@@ -90,12 +90,12 @@ class _RecordingScreenState extends State<RecordingScreen> with RouteAware {
           showDialog(
             context: context,
             builder: (context) => AlertDialog(
-              title: Text(t('Offline režim')),
-              content: Text(t('Jste offline. Budou dostupné pouze lokálně uložené záznamy.')),
+              title: Text(t('recList.offlineMode.title')),
+              content: Text(t('recList.offlineMode.message')),
               actions: [
                 TextButton(
                   onPressed: () => Navigator.of(context).pop(),
-                  child: Text(t('OK')),
+                  child: Text(t('auth.buttons.ok')),
                 ),
               ],
             ),
@@ -117,7 +117,7 @@ class _RecordingScreenState extends State<RecordingScreen> with RouteAware {
         title: Text(title),
         content: Text(message),
         actions: [
-          TextButton(onPressed: () => Navigator.of(context).pop(), child: Text(t('OK'))),
+          TextButton(onPressed: () => Navigator.of(context).pop(), child: Text(t('auth.buttons.ok'))),
         ],
       ),
     );
@@ -166,13 +166,13 @@ class _RecordingScreenState extends State<RecordingScreen> with RouteAware {
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text(t('Třídění a filtry'), style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+                Text(t('recList.buttons.sortAndFilter'), style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
               ],
             ),
             const Divider(),
             ListTile(
                 leading: const Icon(Icons.sort_by_alpha),
-                title: Text(t('Třídit podle názvu')),
+                title: Text(t('recList.buttons.sortByName')),
                 // Highlight active sort option
                 tileColor: sortOptions == SortBy.name ? Colors.grey.withOpacity(0.2) : null,
                 onTap: () {
@@ -188,7 +188,7 @@ class _RecordingScreenState extends State<RecordingScreen> with RouteAware {
             ),
             ListTile(
                 leading: const Icon(Icons.date_range),
-                title: Text(t('Třídit podle data')),
+                title: Text(t('recList.buttons.sortByDate')),
                 tileColor: sortOptions == SortBy.date ? Colors.grey.withOpacity(0.2) : null,
                 onTap: () {
                   setState(() {
@@ -203,7 +203,7 @@ class _RecordingScreenState extends State<RecordingScreen> with RouteAware {
             ),
             ListTile(
                 leading: const Icon(Icons.filter_list),
-                title: Text(t('Počet ptáků')),
+                title: Text(t('recList.buttons.sortByBirdCount')),
                 tileColor: sortOptions == SortBy.ebc ? Colors.grey.withOpacity(0.2) : null,
                 onTap: () {
                   if (sortOptions == SortBy.ebc) {
@@ -219,7 +219,7 @@ class _RecordingScreenState extends State<RecordingScreen> with RouteAware {
             const Divider(),
             ListTile(
                 leading: const Icon(Icons.download),
-                title: Text(t('Stažené')),
+                title: Text(t('recList.buttons.filterDownloaded')),
                 tileColor: sortOptions == SortBy.downloaded ? Colors.grey.withOpacity(0.2) : null,
                 onTap: () {
                   FilterDownloaded();
@@ -235,7 +235,7 @@ class _RecordingScreenState extends State<RecordingScreen> with RouteAware {
             const Divider(),
             ListTile(
                 leading: const Icon(Icons.clear),
-                title: Text(t('Zrušit filtr')),
+                title: Text(t('recList.buttons.clearFilter')),
                 onTap: () {
                   getRecordings();
                   setState(() {
@@ -354,7 +354,7 @@ class _RecordingScreenState extends State<RecordingScreen> with RouteAware {
                   children: [
                     SizedBox(
                       height: 500,
-                      child: Center(child: Text(t('Zatím nemáte žádné záznamy'))),
+                      child: Center(child: Text(t('recList.emptyListMessage'))),
                     )
                   ],
                 )

--- a/lib/localRecordings/recListItem.dart
+++ b/lib/localRecordings/recListItem.dart
@@ -218,12 +218,12 @@ class _RecordingItemState extends State<RecordingItem> {
       showDialog(
         context: context,
         builder: (context) => AlertDialog(
-          title: Text(t('Stahování nedostupné')),
-          content: Text(t('Pro stažení nahrávky je vyžadováno připojení k internetu.')),
+          title: Text(t('recListItem.dialogs.downloadUnavailable.title')),
+          content: Text(t('recListItem.dialogs.downloadUnavailable.message')),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(),
-              child: Text(t('OK')),
+              child: Text(t('auth.buttons.ok')),
             ),
           ],
         ),
@@ -256,7 +256,7 @@ class _RecordingItemState extends State<RecordingItem> {
       logger.e("Error downloading recording: $e", error: e, stackTrace: stackTrace);
       Sentry.captureException(e, stackTrace: stackTrace);
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(t("Error downloading recording"))),
+        SnackBar(content: Text(t('recordingPage.status.errorDownloading'))),
       );
     }
   }
@@ -376,11 +376,11 @@ class _RecordingItemState extends State<RecordingItem> {
                         child: Column(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
-                            Text(t('Nahrávka není dostupná')),
+                            Text(t('recListItem.noRecording')),
                             const SizedBox(height: 8),
                             ElevatedButton(
                               onPressed: _downloadRecording,
-                              child: Text(t('Stáhnout nahrávku')),
+                              child: Text(t('recListItem.buttons.download')),
                             ),
                           ],
                         ),
@@ -428,7 +428,7 @@ class _RecordingItemState extends State<RecordingItem> {
                             children: [
                               Row(
                                 mainAxisAlignment: MainAxisAlignment.center,
-                                children: [Text(t("Datum a čas"))],
+                                children: [Text(t('recListItem.dateTime'))],
                               ),
                               Text(
                                 formatDateTime(widget.recording.createdAt),
@@ -465,7 +465,7 @@ class _RecordingItemState extends State<RecordingItem> {
                         padding: const EdgeInsets.symmetric(vertical: 8.0),
                         child: ElevatedButton.icon(
                           icon: const Icon(Icons.send),
-                          label: Text(t('Odeslat záznam')),
+                          label: Text(t('recListItem.buttons.send')),
                           onPressed: () async {
                             try {
                               // ensure all parts have been sent
@@ -480,11 +480,11 @@ class _RecordingItemState extends State<RecordingItem> {
                               final shouldResend = await showDialog<bool>(
                                 context: context,
                                 builder: (ctx) => AlertDialog(
-                                  title: Text(t('Neodeslané části')),
-                                  content: Text(t('Některé části nahrávky nebyly odeslány. Chcete je zkusit znovu odeslat?')),
+                                  title: Text(t('recList.status.unsentParts')),
+                                  content: Text(t('recListItem.dialogs.unsentParts.message')),
                                   actions: [
-                                    TextButton(onPressed: () => Navigator.of(ctx).pop(false), child: Text(t('Zrušit'))),
-                                    TextButton(onPressed: () => Navigator.of(ctx).pop(true), child: Text(t('Odeslat znovu'))),
+                                    TextButton(onPressed: () => Navigator.of(ctx).pop(false), child: Text(t('recListItem.dialogs.confirmDelete.cancel'))),
+                                    TextButton(onPressed: () => Navigator.of(ctx).pop(true), child: Text(t('recListItem.buttons.resendUnsentParts'))),
                                   ],
                                 ),
                               );
@@ -508,29 +508,29 @@ class _RecordingItemState extends State<RecordingItem> {
                             // Optionally refresh UI or provide feedback
                           });
                         },
-                        child: Text(t('Smazat z cache')),
+                        child: Text(t('recListItem.buttons.deleteCache')),
                       ),
                     ),
                     Padding(
                       padding: const EdgeInsets.symmetric(vertical: 8.0),
                       child: ElevatedButton.icon(
                         icon: const Icon(Icons.delete, color: Colors.white,),
-                        label: Text(t('Smazat záznam'), style: TextStyle(color: Colors.white),),
+                        label: Text(t('recListItem.buttons.delete'), style: TextStyle(color: Colors.white),),
                         style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
                         onPressed: () async {
                           final confirm = await showDialog<bool>(
                             context: context,
                             builder: (ctx) => AlertDialog(
-                              title: Text(t('Potvrdit smazání')),
-                              content: Text(t('Opravdu chcete tento záznam natrvalo smazat?')),
+                              title: Text(t('recListItem.dialogs.confirmDelete.title')),
+                              content: Text(t('recListItem.dialogs.confirmDelete.message')),
                               actions: [
                                 TextButton(
                                   onPressed: () => Navigator.of(ctx).pop(false),
-                                  child: Text(t('Zrušit')),
+                                  child: Text(t('recListItem.dialogs.confirmDelete.cancel')),
                                 ),
                                 TextButton(
                                   onPressed: () => Navigator.of(ctx).pop(true),
-                                  child: Text(t('Smazat')),
+                                  child: Text(t('recListItem.dialogs.confirmDelete.delete')),
                                 ),
                               ],
                             ),

--- a/lib/localization/localization.dart
+++ b/lib/localization/localization.dart
@@ -7,7 +7,20 @@ class Localization {
   static Future<void> load() async {
     final jsonString = await rootBundle.loadString('assets/lang/cs.json');
     final Map<String, dynamic> jsonMap = json.decode(jsonString);
-    _localizedStrings = jsonMap.map((key, value) => MapEntry(key, value.toString()));
+    _localizedStrings = _flatten(jsonMap);
+  }
+
+  static Map<String, String> _flatten(Map<String, dynamic> map, [String prefix = '']) {
+    final result = <String, String>{};
+    map.forEach((key, value) {
+      final newKey = prefix.isEmpty ? key : '$prefix.$key';
+      if (value is Map) {
+        result.addAll(_flatten(value.cast<String, dynamic>(), newKey));
+      } else {
+        result[newKey] = value.toString();
+      }
+    });
+    return result;
   }
 
   static String t(String key) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,7 +59,7 @@ void _showMessage(BuildContext context, String message) {
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
-          child: Text(t('OK')),
+          child: Text(t('auth.buttons.ok')),
         ),
       ],
     ),

--- a/lib/map/RecordingPage.dart
+++ b/lib/map/RecordingPage.dart
@@ -229,7 +229,7 @@ class _RecordingFromMapState extends State<RecordingFromMap> {
     } catch (e, stackTrace) {
       logger.e("Error downloading recording: \$e", error: e, stackTrace: stackTrace);
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(t("Error downloading recording"))),
+        SnackBar(content: Text(t('recordingPage.status.errorDownloading'))),
       );
     }
   }
@@ -304,11 +304,11 @@ class _RecordingFromMapState extends State<RecordingFromMap> {
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      Text(t('Nahrávka není dostupná')),
+                      Text(t('recListItem.noRecording')),
                       const SizedBox(height: 8),
                       ElevatedButton(
                         onPressed: _downloadRecording,
-                        child: Text(t('Stáhnout nahrávku')),
+                        child: Text(t('recListItem.buttons.download')),
                       ),
                     ],
                   ),
@@ -357,7 +357,7 @@ class _RecordingFromMapState extends State<RecordingFromMap> {
                             children: [
                               Row(
                                 mainAxisAlignment: MainAxisAlignment.center,
-                                children: [Text(t("Datum a čas"))],
+                                children: [Text(t('recListItem.dateTime'))],
                               ),
                               Text(
                                 formatDateTime(widget.recording.createdAt),

--- a/lib/map/mapv2.dart
+++ b/lib/map/mapv2.dart
@@ -105,12 +105,12 @@ class _MapScreenV2State extends State<MapScreenV2> {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        title: Text(t('Notification')),
+        title: Text(t('map.dialogs.notification.title')),
         content: Text(message),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
-            child: Text(t('OK')),
+            child: Text(t('auth.buttons.ok')),
           ),
         ],
       ),
@@ -373,12 +373,12 @@ class _MapScreenV2State extends State<MapScreenV2> {
       }
 
       showDialog(context: context, builder: (context) => AlertDialog(
-        title: Text(t('Chyba')),
+        title: Text(t('map.dialogs.error.title')),
         content: Text('${t('Nahrávka nenalezena')} $id'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
-            child: Text(t('Zavřít')),
+            child: Text(t('map.dialogs.error.close')),
           ),
         ],
       ));
@@ -558,7 +558,7 @@ class _MapScreenV2State extends State<MapScreenV2> {
                   padding: const EdgeInsets.symmetric(
                       vertical: 2, horizontal: 4),
                   color: Colors.white70,
-                  child: Text(t('Mapy.cz © Seznam.cz, a.s.'),
+                  child: Text(t('map.legend.mapyCz'),
                     style: TextStyle(fontSize: 12),
                   ),
                 ),
@@ -727,7 +727,7 @@ class _MapScreenV2State extends State<MapScreenV2> {
                                         borderRadius: BorderRadius.circular(12),
                                       ),
                                   ),
-                                  child: Text(t('Klasické')),
+                                  child: Text(t('map.filters.mapView.classic')),
                                 ),
                               ),
                               Padding(
@@ -746,7 +746,7 @@ class _MapScreenV2State extends State<MapScreenV2> {
                                         borderRadius: BorderRadius.circular(12),
                                       ),
                                   ),
-                                  child: Text(t('Letecké')),
+                                  child: Text(t('map.filters.mapView.satellite')),
                                 ),
                               ),
                             ],
@@ -782,7 +782,7 @@ class _MapScreenV2State extends State<MapScreenV2> {
                                         borderRadius: BorderRadius.circular(12),
                                       ),
                                   ),
-                                  child: Text(t('Všichni')),
+                                  child: Text(t('map.filters.recordingAuthor.all')),
                                 ),
                               ),
                               Padding(
@@ -806,7 +806,7 @@ class _MapScreenV2State extends State<MapScreenV2> {
                                         borderRadius: BorderRadius.circular(12),
                                       ),
                                   ),
-                                  child: Text(t('Pouze já')),
+                                  child: Text(t('map.filters.recordingAuthor.me')),
                                 ),
                               ),
                             ],
@@ -990,7 +990,7 @@ class _MapScreenV2State extends State<MapScreenV2> {
                                   _showUnconfirmedDialects = false;
                                 });
                               },
-                              child: Text(t('Resetovat')),
+                              child: Text(t('map.buttons.resetFilters')),
                             ),
                           ),
                           const SizedBox(width: 16),
@@ -1015,7 +1015,7 @@ class _MapScreenV2State extends State<MapScreenV2> {
                                 _fetchDialects();        // refetch dialect data after the setting changes
                                 Navigator.pop(context);
                               },
-                              child: Text(t('Nastavit')),
+                              child: Text(t('map.buttons.set')),
                             ),
                           ),
                         ],
@@ -1076,7 +1076,7 @@ class _MapScreenV2State extends State<MapScreenV2> {
                     borderRadius: BorderRadius.circular(2.5),
                   ),
                 ),
-                Text(t('Legenda'),
+                Text(t('map.legend.title'),
                   style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
                 ),
                 const SizedBox(height: 16),
@@ -1121,7 +1121,7 @@ class _MapScreenV2State extends State<MapScreenV2> {
                           borderRadius: BorderRadius.circular(16.0),
                         ),
                       ),
-                      child: Text(t('Zavřít')),
+                      child: Text(t('map.dialogs.error.close')),
                     ),
                   ),
                 ),

--- a/lib/recording/streamRec.dart
+++ b/lib/recording/streamRec.dart
@@ -157,12 +157,12 @@ void _showMessage(BuildContext context, String message) {
   showDialog(
     context: context,
     builder: (context) => AlertDialog(
-      title: Text(t('Informace')),
+      title: Text(t('streamRec.dialogs.info.title')),
       content: Text(message),
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
-          child: Text(t('OK')),
+          child: Text(t('streamRec.dialogs.info.ok')),
         ),
       ],
     ),
@@ -173,12 +173,12 @@ void exitApp(BuildContext context, String message) {
   showDialog(
     context: context,
     builder: (context) => AlertDialog(
-      title: Text(t('Informace')),
+      title: Text(t('streamRec.dialogs.info.title')),
       content: Text(message),
       actions: [
         TextButton(
           onPressed: () => SystemNavigator.pop(),
-          child: Text(t('OK')),
+          child: Text(t('streamRec.dialogs.info.ok')),
         ),
       ],
     ),
@@ -572,7 +572,7 @@ class _LiveRecState extends State<LiveRec> {
             const SizedBox(height: 10),
             // Status text
             if (_recordState == RecordState.stop) ...[
-              Text(t("Stisknutím zahájíte nahrávání"),
+              Text(t('streamRec.status.stopped'),
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   fontSize: 16,
@@ -581,7 +581,7 @@ class _LiveRecState extends State<LiveRec> {
                 ),
               ),
             ] else if (_recordState == RecordState.record) ...[
-              Text(t("Nahrává se…"),
+              Text(t('streamRec.status.recording'),
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   fontSize: 16,
@@ -590,7 +590,7 @@ class _LiveRecState extends State<LiveRec> {
                 ),
               ),
             ] else if (_recordState == RecordState.pause) ...[
-              Text(t("Nahrávání pozastaveno – klepněte pro obnovení"),
+              Text(t('streamRec.status.paused'),
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   fontSize: 16,
@@ -631,7 +631,7 @@ class _LiveRecState extends State<LiveRec> {
                       children: [
                         Icon(Icons.stop, color: primaryRed),
                         const SizedBox(width: 8),
-                        Text(t("Dokončit a pokračovat"),
+                        Text(t('streamRec.buttons.finishRecording'),
                           style: TextStyle(fontFamily: 'Bricolage Grotesque'),
                         ),
                       ],
@@ -670,7 +670,7 @@ class _LiveRecState extends State<LiveRec> {
                       children: [
                         Icon(Icons.delete, color: Colors.white),
                         const SizedBox(width: 8),
-                        Text(t("Zahodit nahrávání"),
+                        Text(t('streamRec.buttons.discardRecording'),
                           style: TextStyle(fontFamily: 'Bricolage Grotesque'),
                         ),
                       ],
@@ -703,12 +703,12 @@ class _LiveRecState extends State<LiveRec> {
         context: context,
         builder: (BuildContext context) {
           return AlertDialog(
-            title: Text(t('Potvrdit')),
-            content: Text(t('Opravdu chcete opustit nahrávání?')),
+            title: Text(t('streamRec.dialogs.confirmExit.title')),
+            content: Text(t('streamRec.dialogs.confirmExit.message')),
             actions: <Widget>[
               TextButton(
                 onPressed: () => Navigator.of(context).pop(),
-                child: Text(t('Zpět k nahrávání')),
+                child: Text(t('streamRec.dialogs.confirmExit.cancel')),
               ),
               TextButton(
                 onPressed: () {
@@ -716,7 +716,7 @@ class _LiveRecState extends State<LiveRec> {
                   discard = true;
                   Navigator.of(context).pop();
                 },
-                child: Text(t('Opustit nahrávání')),
+                child: Text(t('streamRec.dialogs.confirmExit.confirm')),
               ),
             ],
           );

--- a/lib/user/settingsList.dart
+++ b/lib/user/settingsList.dart
@@ -110,11 +110,11 @@ class MenuScreen extends StatelessWidget {
       children: [
         Padding(
           padding: const EdgeInsets.only(top: 15),
-          child: Text(t('Creators: Marian Pecqueur && Jan Drobílek')),
+          child: Text(t('user.menu.dialogs.aboutApp.creators')),
         ),
         Padding(
           padding: const EdgeInsets.only(top: 8),
-          child: Text(t('Kontakt: info@strnadi.cz, developers@strnadi.cz')),
+          child: Text(t('user.menu.dialogs.aboutApp.contact')),
         ),
       ],
     );

--- a/lib/user/settingsPages/appSettings.dart
+++ b/lib/user/settingsPages/appSettings.dart
@@ -59,7 +59,7 @@ class _SettingsPageState extends State<SettingsPage> {
     return ScaffoldWithBottomBar(
       selectedPage: BottomBarItem.user,
       allawArrowBack: true,
-      appBarTitle: t('Nastavení'),
+      appBarTitle: t('user.settings.title'),
       content: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 20),
         child: Column(
@@ -68,7 +68,7 @@ class _SettingsPageState extends State<SettingsPage> {
             const SizedBox(height: 20),
             _buildSectionTitle(t('Aplikace')),
             _buildSwitchTile(
-              t('Použít mobilní data pro nahrávání'),
+              t('user.settings.fields.useMobileData'),
               useMobileData,
               (value) => setState(() => useMobileData = value),
             ),

--- a/lib/user/settingsPages/userInfo.dart
+++ b/lib/user/settingsPages/userInfo.dart
@@ -173,16 +173,16 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: Text(t("Smazání účtu")),
-        content: Text(t("Opravdu si přejete smazat svůj účet? Tato akce je nevratná.")),
+        title: Text(t('user.profile.dialogs.deleteAccount.title')),
+        content: Text(t('user.profile.dialogs.deleteAccount.message')),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
-            child: Text(t("Zrušit")),
+            child: Text(t('recListItem.dialogs.confirmDelete.cancel')),
           ),
           TextButton(
             onPressed: () => Navigator.pop(context, true),
-            child: Text(t("Smazat"), style: TextStyle(color: Colors.red)),
+            child: Text(t('recListItem.dialogs.confirmDelete.delete'), style: TextStyle(color: Colors.red)),
           ),
         ],
       ),
@@ -231,7 +231,7 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(t('Osobní údaje')),
+        title: Text(t('user.profile.title')),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
           onPressed: () => Navigator.pop(context),
@@ -242,7 +242,7 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
             onPressed: () {
               updateUserData();
             }, // Save action
-            child: Text(t('Uložit'), style: TextStyle(color: Colors.white)),
+            child: Text(t('postRecordingForm.recordingForm.buttons.save'), style: TextStyle(color: Colors.white)),
           ),
         ],
       ),
@@ -270,7 +270,7 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
               ),
               const Divider(),
               ListTile(
-                title: Text(t('Změna hesla')),
+                title: Text(t('user.profile.buttons.changePassword')),
                 trailing: const Icon(Icons.chevron_right),
                 onTap: () {
                   Navigator.push(
@@ -280,7 +280,7 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
                 }, // Open password change
               ),
               ListTile(
-                title: Text(t('Chci si smazat účet'), style: TextStyle(color: Colors.red)),
+                title: Text(t('user.profile.buttons.deleteAccount'), style: TextStyle(color: Colors.red)),
                 trailing: const Icon(Icons.chevron_right),
                 onTap: () {
                   confirmAndDeleteAccount();
@@ -310,7 +310,7 @@ class _ProfileEditPageState extends State<ProfileEditPage> {
       context: context,
       builder: (context) => AlertDialog(
         content: Text(message),
-        actions: [TextButton(onPressed: () => Navigator.pop(context), child: Text(t('OK')))],
+        actions: [TextButton(onPressed: () => Navigator.pop(context), child: Text(t('auth.buttons.ok')))],
       ),
     );
   }

--- a/lib/user/userPage.dart
+++ b/lib/user/userPage.dart
@@ -214,7 +214,7 @@ class _UserPageState extends State<UserPage> {
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
-            child: Text(t('Zrušit')),
+            child: Text(t('recListItem.dialogs.confirmDelete.cancel')),
           ),
           TextButton(
             onPressed: () async {


### PR DESCRIPTION
## Summary
- swap inline Czech strings for structured translation keys across the app
- add missing entries in `cs.json` for bottom bar offline notice, generic dialog title and recording list actions

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c30acb3898832c9a881789d46a756c