### PR TITLE
Fix Mermaid diagram syntax in architecture doc

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,10 +13,10 @@ flowchart TD
   D --> E[Config.loadConfig + loadFirebaseConfig]
   E --> F[Workmanager.initialize]
   F --> G[FlutterForegroundTask.init]
-  G --> H[runApp(MyApp)]
-  H --> I{Permissions granted?}
-  I -- No --> J[PermissionScreen]
-  I -- Yes --> K[Continue bootstrap (Sentry, deep links, Workmanager)]
+  G --> H["runApp(MyApp)"]
+  H --> I{"Permissions granted?"}
+  I -- "No" --> J[PermissionScreen]
+  I -- "Yes" --> K["Continue bootstrap: Sentry, deep links, Workmanager"]
 ```
 
 


### PR DESCRIPTION
## Summary
- escape diagram labels that contained parentheses and punctuation to fix Mermaid parsing

## Testing
- Not run

------
https://chatgpt.com/codex/tasks/task_e_68da4bdfc668832c9792245fee16323e