### PR TITLE
Add App Store Connect localized release notes

### DIFF
--- a/ios/fastlane/metadata/cs-CZ/release_notes.txt
+++ b/ios/fastlane/metadata/cs-CZ/release_notes.txt
@@ -1,0 +1,33 @@
+1.4.14 (2025-11-06)
+- Předvyplňuje krok se jménem při registraci a správně uvolňuje controllery, takže se při návratu do formuláře nezobrazují stará data a nevznikají úniky paměti.
+- Synchronizace na pozadí už nepřepíše nahrávky jiného uživatele – aktualizují se jen záznamy, které patří přihlášenému účtu.
+- Balík závislostí pro Firebase, nahrávání, lokalizaci, audio, notifikace a analytiku byl povýšen na aktuální verze, aby zůstal zabezpečený a kompatibilní.
+
+1.4.13 (2025-11-06)
+- Opravené stahování ze serveru bezpečně zpracuje prázdné seznamy částí a nejprve uloží načtené části, než se záznam znovu použije.
+- Logika zvýraznění filtrovaných částí na mapě nyní používá indikátor stavu 6, takže markery správně zobrazují reprezentativní záznamy.
+
+1.4.12 (2025-11-06)
+- Přidaný překladač klíčových slov nářečí a upravené vykreslování mapy zajišťují sjednocené barvy i pořadí potvrzených a predikovaných nářečí včetně teček pro reprezentativní části.
+- V seznamu lokálních nahrávek přibyl kompaktní režim, hromadné odeslání a vylepšené třídění, takže se s rozsáhlou knihovnou pracuje snáze.
+- Push notifikace jsou spolehlivější díky opětovnému nastavení kanálů a dekódování lokalizovaných datových zpráv.
+
+1.4.11 (2025-11-05)
+- Na mapě přibyl vyhledávací panel na adresy i souřadnice, takže se lze okamžitě přepnout na přesnou polohu.
+- Pipeline pro nahrávání částí zvuku byla přepsána na HTTP multipart s hlášením průběhu každé úlohy na pozadí.
+- Délka nahrávek a ovládací prvky se nyní zobrazují jednotně v seznamu offline souborů i v detailu na mapě.
+- Přidána stránka úspěchů, která kombinuje hráčův postup s celkovým katalogem staženým ze serveru.
+- Stránka propojených služeb umožňuje připojit Apple nebo Google přihlášení vždy, když to účet podporuje.
+
+1.4.10 (2025-10-23)
+- Mapové markery lze nově seskupovat do klastrů nebo zobrazit jednotlivě podle potřeby uživatele.
+- Seznam lokálních nahrávek nabízí kompaktní karty, rychlé třídění a tlačítko „odeslat vše neodeslané“ pro rychlejší synchronizaci.
+
+1.4.09 (2025-10-23)
+- Přihlašovací a registrační obrazovky nyní využívají univerzální překryvný loader, který zabraňuje vícenásobným odesláním během komunikace se serverem.
+- Stránka profilu byla přepracována – načítá, upravuje a obnovuje uživatelská data přes zabezpečené API s odpovídající zpětnou vazbou v aplikaci.
+
+1.4.08 (2025-10-21)
+- Úvodní obrazovka má nové rozhraní s výběrem jazyka, režimem hosta a lepším offline chováním, takže první přihlášení je jednodušší.
+- Profilové fotografie se ukládají do cache a znovu se stahují jen v případě potřeby, čímž se snižuje provoz po síti.
+- Mapové ikony jsou generovány dynamicky s uloženými barvami nářečí a nastavení nabízí přepínač prostředí pro pokročilé uživatele.

--- a/ios/fastlane/metadata/en-US/release_notes.txt
+++ b/ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,0 +1,33 @@
+1.4.14 (2025-11-06)
+- Prefills the name step during registration and disposes the controllers correctly to avoid stale data and leaks when returning to the form.
+- Prevents background sync from overwriting another user’s recording by only updating cached entries that belong to the signed-in account.
+- Upgraded the Firebase, recording, location, audio, notification, and analytics packages to their latest major versions to keep the stack secure and compatible.
+
+1.4.13 (2025-11-06)
+- Fixed server downloads so that recordings without parts are parsed safely and cached parts are inserted reliably before reuse.
+- Corrected the filtered-part highlighting logic on the map so markers show the state-6 indicator for representative detections.
+
+1.4.12 (2025-11-06)
+- Added a dialect keyword translator and reworked map rendering so confirmed and predicted dialects share consistent colours and ordering, including center-dot cues for representative parts.
+- Introduced a compact view, bulk send button, and refreshed sorting controls to manage large local recording libraries more efficiently.
+- Hardened push notifications by re-initialising local channels and decoding localized payloads from data messages.
+
+1.4.11 (2025-11-05)
+- Added an address and coordinate search bar on the map so users can jump to exact locations instantly.
+- Rebuilt the upload pipeline to stream audio parts via HTTP multipart with progress reporting for each background job.
+- Display recording durations and transport controls consistently in both local list items and the map detail view.
+- Added an achievements screen that merges user progress with the global catalogue fetched from the backend.
+- Expanded the connected platforms page so accounts can link Apple or Google sign-in when available.
+
+1.4.10 (2025-10-23)
+- Introduced optional clustering for map markers, letting users toggle between grouped bubbles and individual pins on demand.
+- Enhanced the local recordings list with compact cards, quick sorting, and a "send all unsent" action for faster data synchronization.
+
+1.4.09 (2025-10-23)
+- Wrapped authentication and registration flows in a reusable loader overlay to block duplicate submissions while network requests run.
+- Reworked the profile settings page to fetch, edit, and refresh user data through authenticated API calls with in-app feedback.
+
+1.4.08 (2025-10-21)
+- Redesigned the welcome screen with language selection, guest access, and richer offline handling to simplify first-time sign-in.
+- Cached profile photos locally and only re-downloaded them when necessary to reduce repeated network transfers.
+- Added dynamic map icons with cached dialect colours and environment-aware settings controls for advanced users.


### PR DESCRIPTION
## Summary
- provide English release notes for versions 1.4.08 through 1.4.14 under ios/fastlane/metadata/en-US for App Store Connect
- add the Czech translation of the same release notes under ios/fastlane/metadata/cs-CZ
- remove the markdown changelog in favor of the localized App Store metadata files

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69119191e2d8832c9837efde5c90b25d)