### PR TITLE
Add missing dependency installation to iOS deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -147,6 +147,16 @@ jobs:
           BUILD_ENV_JSON_BASE64: ${{ secrets.BUILD_ENV_JSON_BASE64 }}
         run: bash .github/scripts/restore-build-env.sh
 
+      - name: Install CocoaPods
+        run: gem install cocoapods --no-document
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+
+      - name: Install iOS Pods
+        working-directory: ios
+        run: pod install
+
       - name: Deploy iOS build to TestFlight
         working-directory: ios
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ android/upload_cert.der
 delete.sh
 
 build.env.json
+
+*.p8


### PR DESCRIPTION
This pull request updates the deployment workflow to add steps for installing required iOS and Flutter dependencies before deploying the iOS build to TestFlight. These changes ensure that all necessary packages are installed and configured, which helps prevent build failures during deployment.

**Dependency installation improvements:**

* Added a step to install CocoaPods using `gem install cocoapods --no-document` to ensure the iOS dependency manager is available.
* Added a step to install Flutter dependencies by running `flutter pub get`, ensuring all Dart packages are fetched before the build.
* Added a step to install iOS Pods by running `pod install` in the `ios` directory, making sure all native iOS dependencies are installed.