### PR TITLE
Fix APP-26: Resolve iOS code signing and ensure unique Android build …

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -25,8 +25,11 @@ def resolved_build_number(options)
   build_number = ENV["BUILD_NUMBER"].to_s.strip if build_number.empty?
   build_number = ENV["GITHUB_RUN_NUMBER"].to_s.strip if build_number.empty?
   UI.user_error!("BUILD_NUMBER must be set for CI deployments") if build_number.empty?
+  Integer(build_number)
 
   build_number
+rescue ArgumentError
+  UI.user_error!("BUILD_NUMBER must be an integer, got #{build_number.inspect}")
 end
 
 def resolved_dart_define_file(options)
@@ -51,11 +54,19 @@ def resolved_release_status(options)
   release_status.empty? ? "completed" : release_status
 end
 
+def google_play_tracks_to_check(target_track)
+  tracks = %w[internal alpha beta production]
+  closed_track = ENV["GOOGLE_PLAY_CLOSED_TRACK"].to_s.strip
+  extra_tracks = ENV["GOOGLE_PLAY_VERSION_CODE_TRACKS"].to_s.split(",").map(&:strip)
+
+  (tracks + [closed_track, target_track] + extra_tracks).reject(&:empty?).uniq
+end
+
 platform :android do
   desc "Build a signed Android App Bundle and upload it to a Google Play track"
   lane :play do |options|
     root = project_root
-    build_number = resolved_build_number(options)
+    requested_build_number = resolved_build_number(options)
     build_name = resolved_build_name(options)
     dart_define_file = resolved_dart_define_file(options)
     track = resolved_play_track(options)
@@ -64,6 +75,33 @@ platform :android do
     json_key = File.join(root, "android/play-store-service-account.json") if json_key.empty?
 
     UI.user_error!("Missing Google Play service account JSON: #{json_key}") unless File.exist?(json_key)
+
+    tracks_to_check = google_play_tracks_to_check(track)
+    track_read_errors = {}
+    play_version_codes = tracks_to_check.flat_map do |play_track|
+      google_play_track_version_codes(
+        package_name: PACKAGE_NAME,
+        track: play_track,
+        json_key: json_key
+      )
+    rescue StandardError => error
+      track_read_errors[play_track] = error.message
+      UI.important("Could not read Google Play version codes for #{play_track}: #{error.message}")
+      []
+    end
+    if play_version_codes.empty? && track_read_errors.length == tracks_to_check.length
+      UI.user_error!("Could not read Google Play version codes from any track: #{track_read_errors}")
+    end
+    highest_play_version_code = play_version_codes.map(&:to_i).max
+    build_number = requested_build_number
+
+    if highest_play_version_code && build_number.to_i <= highest_play_version_code
+      build_number = (highest_play_version_code + 1).to_s
+      UI.important(
+        "Requested build number #{requested_build_number} is not higher than Google Play version code " \
+        "#{highest_play_version_code}; building with #{build_number}."
+      )
+    end
 
     Dir.chdir(root) do
       sh(

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -40,5 +40,12 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+
+    target.build_configurations.each do |config|
+      config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+      config.build_settings['CODE_SIGNING_REQUIRED'] = 'NO'
+      config.build_settings['CODE_SIGNING_IDENTITY'] = ''
+      config.build_settings['EXPANDED_CODE_SIGN_IDENTITY'] = ''
+    end
   end
 end

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -120,7 +120,6 @@ platform :ios do
         *xcode_auth_args,
         shell_arg("DEVELOPMENT_TEAM", team_id),
         shell_arg("CODE_SIGN_STYLE", "Automatic"),
-        shell_arg("CODE_SIGN_IDENTITY", "Apple Distribution"),
         shell_arg("CURRENT_PROJECT_VERSION", build_number),
         shell_arg("MARKETING_VERSION", build_name)
       ].join(" "),


### PR DESCRIPTION
This pull request introduces several improvements to the Android and iOS build pipelines, focusing on build number handling, Google Play version code management, and iOS code signing configuration. The most notable changes include automatically incrementing the Android build number if needed, improving error handling, and disabling code signing requirements for iOS builds.

**Android build improvements:**

* The `resolved_build_number` method now validates that the build number is an integer and provides a clear error message if not.
* The build pipeline checks all relevant Google Play tracks for the highest version code, and if the requested build number is not higher, it automatically increments the build number to avoid deployment failures. [[1]](diffhunk://#diff-d0c99c3583617d28a3669e90c98158993dfbd7a57c6e010b1a70e2a8acaed5a6R57-R69) [[2]](diffhunk://#diff-d0c99c3583617d28a3669e90c98158993dfbd7a57c6e010b1a70e2a8acaed5a6R79-R105)

**iOS build improvements:**

* Code signing is now explicitly disabled for all build configurations in the `Podfile`, which helps with CI builds and local development where code signing is not required.
* The `CODE_SIGN_IDENTITY` setting is no longer passed to Xcode build commands, aligning with the new code signing configuration.