### PR TITLE
Added deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,10 +46,12 @@ concurrency:
 
 permissions:
   contents: read
+  deployments: write
 
 env:
   BUILD_NAME: ${{ github.event.inputs.build_name }}
   BUILD_NUMBER: ${{ github.event.inputs.build_number || github.run_number }}
+  DEPLOYMENT_LOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
   GOOGLE_PLAY_TRACK: ${{ github.event.inputs.play_track || (startsWith(github.ref_name, 'release/') && (vars.GOOGLE_PLAY_CLOSED_TRACK || 'alpha')) || 'internal' }}
   GOOGLE_PLAY_RELEASE_STATUS: ${{ github.event.inputs.release_status || 'completed' }}
 
@@ -62,6 +64,19 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Create Android GitHub deployment
+        id: android_deployment
+        uses: chrnorm/deployment-action@v2
+        with:
+          token: ${{ github.token }}
+          ref: ${{ github.sha }}
+          environment: ${{ env.GOOGLE_PLAY_TRACK == 'production' && 'android-production' || 'android-testing' }}
+          task: 'deploy:android'
+          initial-status: in_progress
+          log-url: ${{ env.DEPLOYMENT_LOG_URL }}
+          description: Android deployment to Play Console ${{ env.GOOGLE_PLAY_TRACK }}.
+          production-environment: ${{ env.GOOGLE_PLAY_TRACK == 'production' && 'true' || 'false' }}
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -145,6 +160,28 @@ jobs:
             android/app/build/reports/**
             android/.gradle/**/problems-report.html
 
+      - name: Mark Android deployment failed
+        if: ${{ failure() && steps.android_deployment.outputs.deployment_id != '' }}
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.android_deployment.outputs.deployment_id }}
+          state: failure
+          environment: ${{ env.GOOGLE_PLAY_TRACK == 'production' && 'android-production' || 'android-testing' }}
+          log-url: ${{ env.DEPLOYMENT_LOG_URL }}
+          description: Android deployment to Play Console ${{ env.GOOGLE_PLAY_TRACK }} failed.
+
+      - name: Mark Android deployment successful
+        if: ${{ success() }}
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.android_deployment.outputs.deployment_id }}
+          state: success
+          environment: ${{ env.GOOGLE_PLAY_TRACK == 'production' && 'android-production' || 'android-testing' }}
+          log-url: ${{ env.DEPLOYMENT_LOG_URL }}
+          description: Android deployed to Play Console ${{ env.GOOGLE_PLAY_TRACK }}.
+
       - name: Comment Jira deployment
         if: ${{ success() }}
         env:
@@ -169,6 +206,19 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Create iOS GitHub deployment
+        id: ios_deployment
+        uses: chrnorm/deployment-action@v2
+        with:
+          token: ${{ github.token }}
+          ref: ${{ github.sha }}
+          environment: ios-testflight
+          task: 'deploy:ios'
+          initial-status: in_progress
+          log-url: ${{ env.DEPLOYMENT_LOG_URL }}
+          description: iOS deployment to TestFlight.
+          production-environment: 'false'
 
       - name: Select Xcode 26
         run: |
@@ -268,6 +318,28 @@ jobs:
             ios/build/ios/gym-logs/**
             ios/build/ios/gym-result.xcresult/**
             /Users/runner/Library/Logs/gym/**
+
+      - name: Mark iOS deployment failed
+        if: ${{ failure() && steps.ios_deployment.outputs.deployment_id != '' }}
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.ios_deployment.outputs.deployment_id }}
+          state: failure
+          environment: ios-testflight
+          log-url: ${{ env.DEPLOYMENT_LOG_URL }}
+          description: iOS deployment to TestFlight failed.
+
+      - name: Mark iOS deployment successful
+        if: ${{ success() }}
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          deployment-id: ${{ steps.ios_deployment.outputs.deployment_id }}
+          state: success
+          environment: ios-testflight
+          log-url: ${{ env.DEPLOYMENT_LOG_URL }}
+          description: iOS deployed to TestFlight.
 
       - name: Comment Jira deployment
         if: ${{ success() }}

--- a/.jira/config.yml
+++ b/.jira/config.yml
@@ -1,0 +1,18 @@
+deployments:
+  environmentMapping:
+    development:
+      - "development"
+      - "dev*"
+    testing:
+      - "android-testing"
+      - "ios-testflight"
+      - "test*"
+    staging:
+      - "staging"
+      - "stage*"
+      - "preprod"
+      - "pre-prod"
+    production:
+      - "android-production"
+      - "production"
+      - "prod*"

--- a/docs/jira-workflow.md
+++ b/docs/jira-workflow.md
@@ -25,7 +25,11 @@ The `Branch and Jira Policy` workflow validates feature and release branch names
 - Push to `release/**`: deploys Android to the closed testing track and iOS to TestFlight.
 - The closed testing track defaults to `alpha`; set the `GOOGLE_PLAY_CLOSED_TRACK` repository variable if your Play Console closed-testing track uses another name.
 - Manual deploys can override the Play track with the `play_track` workflow input.
-- If a deploy branch contains a Jira issue key, the deploy workflow comments on that Jira issue after successful Android and iOS uploads.
+- The deploy workflow creates GitHub deployment events and status updates so Jira can show Android and iOS deployments in the Deployments view.
+- Android deployments use the `android-testing` environment unless the Play track is `production`, in which case they use `android-production`.
+- iOS TestFlight deployments use the `ios-testflight` environment.
+- Custom deployment environments are mapped for Jira in `.jira/config.yml`.
+- If a deploy branch contains a Jira issue key, the deploy workflow also comments on that Jira issue after successful Android and iOS uploads.
 
 ## Required GitHub Variables
 


### PR DESCRIPTION
This pull request introduces GitHub deployment events and status updates for both Android and iOS deploy workflows, enabling Jira to display mobile deployments in the Deployments view. It also adds environment mappings to `.jira/config.yml` for accurate Jira integration and updates documentation to reflect these changes.

**GitHub Deployments and Status Updates:**

* Added steps to the deploy workflow to create GitHub deployment events for Android and iOS, including marking deployments as successful or failed based on workflow outcome (`.github/workflows/deploy.yml`). [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R68-R80) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R163-R184) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R210-R222) [[4]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R322-R343)
* Android deployments now use the `android-testing` environment unless deploying to production, which uses `android-production`. iOS TestFlight deployments use the `ios-testflight` environment. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R68-R80) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R210-R222)

**Jira Integration:**

* Added a `deployments.environmentMapping` section to `.jira/config.yml` to map deployment environments for Jira Deployments view.

**Documentation Updates:**

* Updated `docs/jira-workflow.md` to describe the new deployment events, environment naming, and Jira environment mapping.

**Workflow Permissions:**

* Granted `deployments: write` permission in the deploy workflow to allow creation of deployment events.

**Deployment Log URL:**

* Added a `DEPLOYMENT_LOG_URL` environment variable for linking workflow logs in deployment events.

These changes improve traceability of mobile deployments and enhance visibility in Jira.