### PR TITLE
APP-28 Fixed deployments jira linking

### DIFF
--- a/.github/scripts/validate-branch-name.sh
+++ b/.github/scripts/validate-branch-name.sh
@@ -55,7 +55,7 @@ if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   commit_subjects="$(git log --format='%H%x09%s' "$commit_range" || true)"
 
   if [[ "$branch_name" == feature/* && -n "$commit_subjects" ]]; then
-    if ! printf '%s' "$commit_subjects" | grep -Eq "$jira_key_pattern"; then
+    if [[ ! "$commit_subjects" =~ $jira_key_pattern ]]; then
       echo "::error::At least one feature branch commit subject must include a Jira issue key so Jira can link deployments."
       exit 1
     fi

--- a/.github/scripts/validate-branch-name.sh
+++ b/.github/scripts/validate-branch-name.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 branch_name="${BRANCH_NAME:-}"
 jira_project_keys="${JIRA_PROJECT_KEYS:-APP}"
+pr_title="${PR_TITLE:-}"
 
 if [[ -z "$branch_name" ]]; then
   echo "::error::BRANCH_NAME is required."
@@ -35,7 +36,33 @@ case "$branch_name" in
     ;;
 esac
 
-source_text="${branch_name} ${PR_TITLE:-} ${PR_BODY:-}"
+if [[ "$branch_name" == feature/* && -n "$pr_title" && ! "$pr_title" =~ $jira_key_pattern ]]; then
+  echo "::error::Pull request titles must include a Jira issue key, for example APP-24 Fix spacing."
+  exit 1
+fi
+
+commit_subjects=""
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  commit_range="HEAD"
+
+  if [[ -n "${BASE_BRANCH:-}" ]]; then
+    base_ref="origin/${BASE_BRANCH}"
+    if git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+      commit_range="${base_ref}..HEAD"
+    fi
+  fi
+
+  commit_subjects="$(git log --format='%H%x09%s' "$commit_range" || true)"
+
+  if [[ "$branch_name" == feature/* && -n "$commit_subjects" ]]; then
+    if ! printf '%s' "$commit_subjects" | grep -Eq "$jira_key_pattern"; then
+      echo "::error::At least one feature branch commit subject must include a Jira issue key so Jira can link deployments."
+      exit 1
+    fi
+  fi
+fi
+
+source_text="${branch_name} ${PR_TITLE:-} ${PR_BODY:-} ${commit_subjects}"
 jira_keys="$(printf '%s' "$source_text" | grep -Eo "$jira_key_pattern" | sort -u | tr '\n' ' ' || true)"
 
 if [[ "$branch_name" == feature/* && -z "${jira_keys// /}" ]]; then

--- a/.github/workflows/branch-policy.yml
+++ b/.github/workflows/branch-policy.yml
@@ -24,9 +24,13 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Validate Jira branch convention
         env:
+          BASE_BRANCH: ${{ github.base_ref }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,8 @@ jobs:
         uses: chrnorm/deployment-action@v2
         with:
           token: ${{ github.token }}
-          ref: ${{ github.sha }}
+          ref: ${{ github.ref_name }}
+          sha: ${{ github.sha }}
           environment: ${{ env.GOOGLE_PLAY_TRACK == 'production' && 'android-production' || 'android-testing' }}
           task: 'deploy:android'
           initial-status: in_progress
@@ -212,7 +213,8 @@ jobs:
         uses: chrnorm/deployment-action@v2
         with:
           token: ${{ github.token }}
-          ref: ${{ github.sha }}
+          ref: ${{ github.ref_name }}
+          sha: ${{ github.sha }}
           environment: ios-testflight
           task: 'deploy:ios'
           initial-status: in_progress

--- a/docs/jira-workflow.md
+++ b/docs/jira-workflow.md
@@ -15,7 +15,9 @@ The `Branch and Jira Policy` workflow validates feature and release branch names
 ## Pull Requests
 
 - Feature branches should include the Jira key in the branch name and PR template.
-- Jira issue keys are detected from the branch, title, and PR body.
+- Pull request titles must include the Jira key so GitHub for Jira can link the PR natively.
+- At least one feature branch commit subject must include the Jira key so GitHub for Jira can link builds and deployments.
+- Jira issue keys are detected from the branch, title, PR body, and commit subjects.
 - If `JIRA_USER_EMAIL` and `JIRA_API_TOKEN` are configured, the workflow verifies that detected Jira issues exist.
 - On PR open, reopen, or ready-for-review, the workflow adds a Jira comment with the GitHub PR link.
 
@@ -26,6 +28,7 @@ The `Branch and Jira Policy` workflow validates feature and release branch names
 - The closed testing track defaults to `alpha`; set the `GOOGLE_PLAY_CLOSED_TRACK` repository variable if your Play Console closed-testing track uses another name.
 - Manual deploys can override the Play track with the `play_track` workflow input.
 - The deploy workflow creates GitHub deployment events and status updates so Jira can show Android and iOS deployments in the Deployments view.
+- Deployment events use the deployed branch name as the GitHub deployment ref and pin the exact deployed commit SHA.
 - Android deployments use the `android-testing` environment unless the Play track is `production`, in which case they use `android-production`.
 - iOS TestFlight deployments use the `ios-testflight` environment.
 - Custom deployment environments are mapped for Jira in `.jira/config.yml`.


### PR DESCRIPTION
This pull request strengthens the enforcement of Jira issue key conventions in feature branch workflows, improves integration with GitHub for Jira, and clarifies deployment event metadata. The main changes include stricter validation of pull request titles and commit subjects for Jira keys, updates to workflow scripts to support these checks, and documentation improvements to reflect the new requirements and deployment behaviors.

**Jira key enforcement and validation:**

* The branch validation script (`.github/scripts/validate-branch-name.sh`) now requires pull request titles for feature branches to include a Jira issue key, and at least one commit subject must also include a Jira key for proper linking with Jira deployments. [[1]](diffhunk://#diff-13c2db8d95d0ed1aae6dd8a3bcc25ef6b425b7d987d49feb10e5f08be57516d0R6) [[2]](diffhunk://#diff-13c2db8d95d0ed1aae6dd8a3bcc25ef6b425b7d987d49feb10e5f08be57516d0L38-R65)
* The branch policy workflow (`.github/workflows/branch-policy.yml`) is updated to fetch the full git history and pass the base branch reference to support commit subject validation.

**Deployment workflow improvements:**

* The deploy workflow (`.github/workflows/deploy.yml`) now sets the GitHub deployment ref to the deployed branch name and pins the exact commit SHA, improving traceability for Jira deployments. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L73-R74) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L215-R217)

**Documentation updates:**

* The Jira workflow documentation (`docs/jira-workflow.md`) is updated to explain the new requirements for pull request titles and commit subjects, and to clarify how deployment events are associated with branch names and commit SHAs. [[1]](diffhunk://#diff-c7d91a28f5dbe3a0d8b265f1f62bdeedb6d5f7d62ad040cce8504984d1e05f28L18-R20) [[2]](diffhunk://#diff-c7d91a28f5dbe3a0d8b265f1f62bdeedb6d5f7d62ad040cce8504984d1e05f28R31)