### PR TITLE
APP-28: Refactor mobile deployment for staged releases and Jira integ…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@ Please describe the changes in this PR:
 ## Jira
 
 - Jira issue: APP-000
+- Jira release / fixVersion: 1.6.0
 - Branch: feature/APP-000-short-description
 
 ## Type of Change

--- a/.github/scripts/release-jira.sh
+++ b/.github/scripts/release-jira.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+jira_project_keys="${JIRA_PROJECT_KEYS:-APP}"
+target_status="${JIRA_TARGET_STATUS:-To Test}"
+branch_name="${BRANCH_NAME:-${GITHUB_REF_NAME:-}}"
+release_version="${JIRA_RELEASE_VERSION:-}"
+deployment_stage="${DEPLOYMENT_STAGE:-release_candidate}"
+
+if [[ "$deployment_stage" != "release_candidate" ]]; then
+  echo "Jira release-candidate update skipped for deployment stage: ${deployment_stage}."
+  exit 0
+fi
+
+if [[ "$branch_name" != release/* && -z "$release_version" ]]; then
+  echo "Jira release-candidate update skipped because this is not a release branch."
+  exit 0
+fi
+
+if [[ -z "${JIRA_BASE_URL:-}" || -z "${JIRA_USER_EMAIL:-}" || -z "${JIRA_API_TOKEN:-}" ]]; then
+  echo "Jira credentials are not configured. Skipping release issue transitions."
+  exit 0
+fi
+
+project_pattern="$(printf '%s' "$jira_project_keys" | tr ',' '|' | tr -d '[:space:]')"
+jira_key_pattern="(${project_pattern})-[0-9]+"
+
+if [[ -z "$release_version" ]]; then
+  release_version="${branch_name#release/}"
+  if [[ "$release_version" =~ ^${jira_key_pattern}[-/](.+)$ ]]; then
+    release_version="${BASH_REMATCH[2]}"
+  fi
+fi
+
+if [[ -z "$release_version" ]]; then
+  echo "::error::Could not determine Jira release version from branch '${branch_name}'."
+  exit 1
+fi
+
+project_list="$(
+  printf '%s' "$jira_project_keys" |
+    tr ',' '\n' |
+    sed 's/^[[:space:]]*//;s/[[:space:]]*$//' |
+    awk 'NF { printf "%s\"%s\"", sep, $0; sep = "," }'
+)"
+
+jql="project in (${project_list}) AND fixVersion = \"${release_version}\" AND issuetype in (Feature, Story, Task, Bug) ORDER BY key"
+
+echo "Finding Jira issues for release ${release_version}."
+issues_response="$(
+  curl -sS \
+    -u "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+    -H "Accept: application/json" \
+    --get \
+    --data-urlencode "jql=${jql}" \
+    --data-urlencode "fields=summary,status" \
+    --data-urlencode "maxResults=100" \
+    "${JIRA_BASE_URL%/}/rest/api/3/search"
+)"
+
+issue_keys="$(printf '%s' "$issues_response" | jq -r '.issues[].key')"
+
+if [[ -z "$issue_keys" ]]; then
+  echo "No Jira issues found for fixVersion '${release_version}'."
+  exit 0
+fi
+
+comment_text="${JIRA_COMMENT_BODY:-Release ${release_version} has been deployed from ${branch_name} and is ready for QA testing.
+
+Workflow run: ${DEPLOYMENT_LOG_URL:-}}"
+comment_payload="$(jq -n --arg text "$comment_text" '{
+  body: {
+    type: "doc",
+    version: 1,
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: $text
+          }
+        ]
+      }
+    ]
+  }
+}')"
+
+while IFS= read -r issue_key; do
+  [[ -n "$issue_key" ]] || continue
+
+  curl -sS \
+    -u "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+    -H "Accept: application/json" \
+    -H "Content-Type: application/json" \
+    --data "$comment_payload" \
+    "${JIRA_BASE_URL%/}/rest/api/3/issue/${issue_key}/comment" \
+    >/dev/null
+
+  transitions="$(
+    curl -sS \
+      -u "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+      -H "Accept: application/json" \
+      "${JIRA_BASE_URL%/}/rest/api/3/issue/${issue_key}/transitions"
+  )"
+  transition_id="$(
+    printf '%s' "$transitions" |
+      jq -r --arg target "$target_status" '
+        .transitions[]
+        | select((.name | ascii_downcase) == ($target | ascii_downcase) or (.to.name | ascii_downcase) == ($target | ascii_downcase))
+        | .id
+      ' |
+      head -n 1
+  )"
+
+  if [[ -z "$transition_id" ]]; then
+    echo "::warning::${issue_key} was commented, but no transition to '${target_status}' is available."
+    continue
+  fi
+
+  transition_payload="$(jq -n --arg id "$transition_id" '{ transition: { id: $id } }')"
+  curl -sS \
+    -u "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+    -H "Accept: application/json" \
+    -H "Content-Type: application/json" \
+    --data "$transition_payload" \
+    "${JIRA_BASE_URL%/}/rest/api/3/issue/${issue_key}/transitions" \
+    >/dev/null
+
+  echo "Updated ${issue_key}: commented and transitioned to ${target_status}."
+done <<< "$issue_keys"

--- a/.github/scripts/restore-google-play-service-account.sh
+++ b/.github/scripts/restore-google-play-service-account.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64:?Set the GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64 GitHub secret.}"
+
+base64_decode() {
+  if printf '' | base64 --decode >/dev/null 2>&1; then
+    base64 --decode
+  else
+    base64 -D
+  fi
+}
+
+printf '%s' "$GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64" | base64_decode > android/play-store-service-account.json
+jq empty android/play-store-service-account.json
+chmod 600 android/play-store-service-account.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,11 +16,20 @@ on:
           - all
           - ios
           - android
-      play_track:
-        description: Google Play track, for example internal, alpha, beta, or a custom closed-testing track name.
+      deployment_stage:
+        description: Release stage to run.
         required: true
+        type: choice
+        default: release_candidate
+        options:
+          - internal
+          - release_candidate
+          - external_beta
+          - production
+      play_track:
+        description: Optional Google Play target track override. Leave empty to derive it from the deployment stage.
+        required: false
         type: string
-        default: internal
       release_status:
         description: Google Play release status.
         required: true
@@ -39,9 +48,30 @@ on:
         description: Optional build number override. Defaults to the GitHub run number.
         required: false
         type: string
+      testflight_groups:
+        description: Comma-separated TestFlight external groups for external beta.
+        required: false
+        type: string
+        default: External
+      testflight_build_number:
+        description: Optional existing TestFlight build number to distribute externally.
+        required: false
+        type: string
+      app_store_build_number:
+        description: Optional existing TestFlight build number to submit to App Store review.
+        required: false
+        type: string
+      app_store_app_version:
+        description: Optional App Store version to submit. Defaults to the editable App Store Connect version.
+        required: false
+        type: string
+      jira_release_version:
+        description: Optional Jira fixVersion. Defaults to the release branch version.
+        required: false
+        type: string
 
 concurrency:
-  group: deploy-${{ github.ref }}-${{ github.event.inputs.platform || 'push' }}
+  group: deploy-${{ github.ref }}-${{ github.event.inputs.platform || 'push' }}-${{ github.event.inputs.deployment_stage || 'push' }}
   cancel-in-progress: false
 
 permissions:
@@ -51,9 +81,21 @@ permissions:
 env:
   BUILD_NAME: ${{ github.event.inputs.build_name }}
   BUILD_NUMBER: ${{ github.event.inputs.build_number || github.run_number }}
+  DEPLOYMENT_STAGE: ${{ github.event.inputs.deployment_stage || (startsWith(github.ref_name, 'release/') && 'release_candidate') || 'internal' }}
   DEPLOYMENT_LOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  GOOGLE_PLAY_TRACK: ${{ github.event.inputs.play_track || (startsWith(github.ref_name, 'release/') && (vars.GOOGLE_PLAY_CLOSED_TRACK || 'alpha')) || 'internal' }}
+  GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK: ${{ vars.GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK || vars.GOOGLE_PLAY_CLOSED_TRACK || 'alpha' }}
+  GOOGLE_PLAY_OPEN_BETA_TRACK: ${{ vars.GOOGLE_PLAY_OPEN_BETA_TRACK || 'beta' }}
+  GOOGLE_PLAY_TRACK: ${{ github.event.inputs.play_track || (github.event.inputs.deployment_stage == 'production' && 'production') || (github.event.inputs.deployment_stage == 'external_beta' && (vars.GOOGLE_PLAY_OPEN_BETA_TRACK || 'beta')) || (github.event.inputs.deployment_stage == 'release_candidate' && (vars.GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK || vars.GOOGLE_PLAY_CLOSED_TRACK || 'alpha')) || (startsWith(github.ref_name, 'release/') && (vars.GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK || vars.GOOGLE_PLAY_CLOSED_TRACK || 'alpha')) || 'internal' }}
+  GOOGLE_PLAY_PROMOTE_FROM_TRACK: ${{ (github.event.inputs.deployment_stage == 'production' && (vars.GOOGLE_PLAY_OPEN_BETA_TRACK || 'beta')) || (github.event.inputs.deployment_stage == 'external_beta' && (vars.GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK || vars.GOOGLE_PLAY_CLOSED_TRACK || 'alpha')) || '' }}
+  GOOGLE_PLAY_PROMOTE_TO_TRACK: ${{ github.event.inputs.play_track || (github.event.inputs.deployment_stage == 'production' && 'production') || (github.event.inputs.deployment_stage == 'external_beta' && (vars.GOOGLE_PLAY_OPEN_BETA_TRACK || 'beta')) || '' }}
   GOOGLE_PLAY_RELEASE_STATUS: ${{ github.event.inputs.release_status || 'completed' }}
+  ANDROID_PROMOTE_ONLY: ${{ (github.event.inputs.deployment_stage == 'external_beta' || github.event.inputs.deployment_stage == 'production') && 'true' || 'false' }}
+  TESTFLIGHT_GROUPS: ${{ github.event.inputs.testflight_groups || 'External' }}
+  TESTFLIGHT_BUILD_NUMBER: ${{ github.event.inputs.testflight_build_number }}
+  TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: "true"
+  APP_STORE_BUILD_NUMBER: ${{ github.event.inputs.app_store_build_number }}
+  APP_STORE_APP_VERSION: ${{ github.event.inputs.app_store_app_version }}
+  JIRA_RELEASE_VERSION: ${{ github.event.inputs.jira_release_version }}
 
 jobs:
   deploy_android:
@@ -76,16 +118,18 @@ jobs:
           task: 'deploy:android'
           initial-status: in_progress
           log-url: ${{ env.DEPLOYMENT_LOG_URL }}
-          description: Android deployment to Play Console ${{ env.GOOGLE_PLAY_TRACK }}.
+          description: Android ${{ env.DEPLOYMENT_STAGE }} deployment to Play Console ${{ env.GOOGLE_PLAY_TRACK }}.
           production-environment: ${{ env.GOOGLE_PLAY_TRACK == 'production' && 'true' || 'false' }}
 
       - name: Set up Java
+        if: ${{ env.ANDROID_PROMOTE_ONLY != 'true' }}
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Set up Flutter
+        if: ${{ env.ANDROID_PROMOTE_ONLY != 'true' }}
         uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ vars.FLUTTER_VERSION || '3.41.2' }}
@@ -93,6 +137,7 @@ jobs:
           cache: true
 
       - name: Cache Flutter pub packages
+        if: ${{ env.ANDROID_PROMOTE_ONLY != 'true' }}
         uses: actions/cache@v4
         with:
           path: ~/.pub-cache
@@ -101,6 +146,7 @@ jobs:
             ${{ runner.os }}-pub-
 
       - name: Cache Gradle
+        if: ${{ env.ANDROID_PROMOTE_ONLY != 'true' }}
         uses: actions/cache@v4
         with:
           path: |
@@ -119,11 +165,13 @@ jobs:
           bundler-cache: true
 
       - name: Restore build environment file
+        if: ${{ env.ANDROID_PROMOTE_ONLY != 'true' }}
         env:
           BUILD_ENV_JSON_BASE64: ${{ secrets.BUILD_ENV_JSON_BASE64 }}
         run: bash .github/scripts/restore-build-env.sh
 
       - name: Restore Android signing and Play credentials
+        if: ${{ env.ANDROID_PROMOTE_ONLY != 'true' }}
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -132,7 +180,14 @@ jobs:
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64 }}
         run: bash .github/scripts/restore-android-secrets.sh
 
+      - name: Restore Google Play credentials
+        if: ${{ env.ANDROID_PROMOTE_ONLY == 'true' }}
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64 }}
+        run: bash .github/scripts/restore-google-play-service-account.sh
+
       - name: Validate Android signing key
+        if: ${{ env.ANDROID_PROMOTE_ONLY != 'true' }}
         env:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
@@ -144,10 +199,18 @@ jobs:
             >/dev/null
 
       - name: Deploy Android App Bundle
+        if: ${{ env.ANDROID_PROMOTE_ONLY != 'true' }}
         working-directory: android
         env:
           SUPPLY_JSON_KEY: ${{ github.workspace }}/android/play-store-service-account.json
         run: bundle exec fastlane play
+
+      - name: Promote Android release
+        if: ${{ env.ANDROID_PROMOTE_ONLY == 'true' }}
+        working-directory: android
+        env:
+          SUPPLY_JSON_KEY: ${{ github.workspace }}/android/play-store-service-account.json
+        run: bundle exec fastlane promote
 
       - name: Upload Android failure reports
         if: ${{ failure() }}
@@ -170,7 +233,7 @@ jobs:
           state: failure
           environment: ${{ env.GOOGLE_PLAY_TRACK == 'production' && 'android-production' || 'android-testing' }}
           log-url: ${{ env.DEPLOYMENT_LOG_URL }}
-          description: Android deployment to Play Console ${{ env.GOOGLE_PLAY_TRACK }} failed.
+          description: Android ${{ env.DEPLOYMENT_STAGE }} deployment to Play Console ${{ env.GOOGLE_PLAY_TRACK }} failed.
 
       - name: Mark Android deployment successful
         if: ${{ success() }}
@@ -181,7 +244,7 @@ jobs:
           state: success
           environment: ${{ env.GOOGLE_PLAY_TRACK == 'production' && 'android-production' || 'android-testing' }}
           log-url: ${{ env.DEPLOYMENT_LOG_URL }}
-          description: Android deployed to Play Console ${{ env.GOOGLE_PLAY_TRACK }}.
+          description: Android ${{ env.DEPLOYMENT_STAGE }} deployed to Play Console ${{ env.GOOGLE_PLAY_TRACK }}.
 
       - name: Comment Jira deployment
         if: ${{ success() }}
@@ -192,7 +255,7 @@ jobs:
           JIRA_PROJECT_KEYS: ${{ vars.JIRA_PROJECT_KEYS || 'APP' }}
           BRANCH_NAME: ${{ github.ref_name }}
           JIRA_COMMENT_BODY: |
-            Android build deployed from Strnadi-Mobile-App.
+            Android ${{ env.DEPLOYMENT_STAGE }} deployment completed from Strnadi-Mobile-App.
 
             Branch: ${{ github.ref_name }}
             Play track: ${{ env.GOOGLE_PLAY_TRACK }}
@@ -215,14 +278,15 @@ jobs:
           token: ${{ github.token }}
           ref: ${{ github.ref_name }}
           sha: ${{ github.sha }}
-          environment: ios-testflight
+          environment: ${{ env.DEPLOYMENT_STAGE == 'production' && 'ios-app-store' || (env.DEPLOYMENT_STAGE == 'external_beta' && 'ios-testflight-external') || 'ios-testflight' }}
           task: 'deploy:ios'
           initial-status: in_progress
           log-url: ${{ env.DEPLOYMENT_LOG_URL }}
-          description: iOS deployment to TestFlight.
-          production-environment: 'false'
+          description: iOS ${{ env.DEPLOYMENT_STAGE }} deployment.
+          production-environment: ${{ env.DEPLOYMENT_STAGE == 'production' && 'true' || 'false' }}
 
       - name: Select Xcode 26
+        if: ${{ env.DEPLOYMENT_STAGE == 'internal' || env.DEPLOYMENT_STAGE == 'release_candidate' }}
         run: |
           xcode_app="$(find /Applications -maxdepth 1 -name 'Xcode_26*.app' -print | sort | tail -n 1)"
           if [[ -n "$xcode_app" ]]; then
@@ -232,6 +296,7 @@ jobs:
           xcrun --sdk iphoneos --show-sdk-version
 
       - name: Set up Flutter
+        if: ${{ env.DEPLOYMENT_STAGE == 'internal' || env.DEPLOYMENT_STAGE == 'release_candidate' }}
         uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ vars.FLUTTER_VERSION || '3.41.2' }}
@@ -239,6 +304,7 @@ jobs:
           cache: true
 
       - name: Cache Flutter pub packages
+        if: ${{ env.DEPLOYMENT_STAGE == 'internal' || env.DEPLOYMENT_STAGE == 'release_candidate' }}
         uses: actions/cache@v4
         with:
           path: ~/.pub-cache
@@ -254,6 +320,7 @@ jobs:
           bundler-cache: true
 
       - name: Cache CocoaPods
+        if: ${{ env.DEPLOYMENT_STAGE == 'internal' || env.DEPLOYMENT_STAGE == 'release_candidate' }}
         uses: actions/cache@v4
         with:
           path: |
@@ -264,6 +331,7 @@ jobs:
             ${{ runner.os }}-pods-
 
       - name: Cache Xcode DerivedData
+        if: ${{ env.DEPLOYMENT_STAGE == 'internal' || env.DEPLOYMENT_STAGE == 'release_candidate' }}
         uses: actions/cache@v4
         with:
           path: build/ios/DerivedData
@@ -273,11 +341,13 @@ jobs:
             ${{ runner.os }}-xcode-deriveddata-
 
       - name: Restore build environment file
+        if: ${{ env.DEPLOYMENT_STAGE == 'internal' || env.DEPLOYMENT_STAGE == 'release_candidate' }}
         env:
           BUILD_ENV_JSON_BASE64: ${{ secrets.BUILD_ENV_JSON_BASE64 }}
         run: bash .github/scripts/restore-build-env.sh
 
       - name: Restore iOS manual signing assets
+        if: ${{ env.DEPLOYMENT_STAGE == 'internal' || env.DEPLOYMENT_STAGE == 'release_candidate' }}
         env:
           IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
           IOS_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
@@ -285,17 +355,21 @@ jobs:
         run: bash .github/scripts/restore-ios-signing.sh
 
       - name: Verify CocoaPods
+        if: ${{ env.DEPLOYMENT_STAGE == 'internal' || env.DEPLOYMENT_STAGE == 'release_candidate' }}
         working-directory: ios
         run: bundle exec pod --version
 
       - name: Install Flutter dependencies
+        if: ${{ env.DEPLOYMENT_STAGE == 'internal' || env.DEPLOYMENT_STAGE == 'release_candidate' }}
         run: flutter pub get
 
       - name: Install iOS Pods
+        if: ${{ env.DEPLOYMENT_STAGE == 'internal' || env.DEPLOYMENT_STAGE == 'release_candidate' }}
         working-directory: ios
         run: bundle exec pod install
 
       - name: Deploy iOS build to TestFlight
+        if: ${{ env.DEPLOYMENT_STAGE == 'internal' || env.DEPLOYMENT_STAGE == 'release_candidate' }}
         working-directory: ios
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
@@ -307,6 +381,31 @@ jobs:
           set -o pipefail
           bundle exec fastlane testflight --verbose 2>&1 | tee ../build/ios/fastlane-testflight.log
 
+      - name: Distribute iOS build to external TestFlight group
+        if: ${{ env.DEPLOYMENT_STAGE == 'external_beta' }}
+        working-directory: ios
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+        run: |
+          mkdir -p ../build/ios
+          set -o pipefail
+          bundle exec fastlane external_beta --verbose 2>&1 | tee ../build/ios/fastlane-external-beta.log
+
+      - name: Submit iOS build to App Store review
+        if: ${{ env.DEPLOYMENT_STAGE == 'production' }}
+        working-directory: ios
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+          IOS_USES_NON_EXEMPT_ENCRYPTION: ${{ vars.IOS_USES_NON_EXEMPT_ENCRYPTION || 'false' }}
+        run: |
+          mkdir -p ../build/ios
+          set -o pipefail
+          bundle exec fastlane app_store --verbose 2>&1 | tee ../build/ios/fastlane-app-store.log
+
       - name: Upload iOS failure logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
@@ -315,6 +414,8 @@ jobs:
           if-no-files-found: ignore
           path: |
             build/ios/fastlane-testflight.log
+            build/ios/fastlane-external-beta.log
+            build/ios/fastlane-app-store.log
             build/ios/gym-logs/**
             build/ios/gym-result.xcresult/**
             ios/build/ios/gym-logs/**
@@ -328,9 +429,9 @@ jobs:
           token: ${{ github.token }}
           deployment-id: ${{ steps.ios_deployment.outputs.deployment_id }}
           state: failure
-          environment: ios-testflight
+          environment: ${{ env.DEPLOYMENT_STAGE == 'production' && 'ios-app-store' || (env.DEPLOYMENT_STAGE == 'external_beta' && 'ios-testflight-external') || 'ios-testflight' }}
           log-url: ${{ env.DEPLOYMENT_LOG_URL }}
-          description: iOS deployment to TestFlight failed.
+          description: iOS ${{ env.DEPLOYMENT_STAGE }} deployment failed.
 
       - name: Mark iOS deployment successful
         if: ${{ success() }}
@@ -339,9 +440,9 @@ jobs:
           token: ${{ github.token }}
           deployment-id: ${{ steps.ios_deployment.outputs.deployment_id }}
           state: success
-          environment: ios-testflight
+          environment: ${{ env.DEPLOYMENT_STAGE == 'production' && 'ios-app-store' || (env.DEPLOYMENT_STAGE == 'external_beta' && 'ios-testflight-external') || 'ios-testflight' }}
           log-url: ${{ env.DEPLOYMENT_LOG_URL }}
-          description: iOS deployed to TestFlight.
+          description: iOS ${{ env.DEPLOYMENT_STAGE }} deployment completed.
 
       - name: Comment Jira deployment
         if: ${{ success() }}
@@ -352,8 +453,39 @@ jobs:
           JIRA_PROJECT_KEYS: ${{ vars.JIRA_PROJECT_KEYS || 'APP' }}
           BRANCH_NAME: ${{ github.ref_name }}
           JIRA_COMMENT_BODY: |
-            iOS build deployed to TestFlight from Strnadi-Mobile-App.
+            iOS ${{ env.DEPLOYMENT_STAGE }} deployment completed from Strnadi-Mobile-App.
 
             Branch: ${{ github.ref_name }}
             Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: bash .github/scripts/comment-jira.sh
+
+  notify_jira_release_candidate:
+    name: Mark Jira release ready for testing
+    runs-on: ubuntu-latest
+    needs:
+      - deploy_android
+      - deploy_ios
+    if: ${{ always() && needs.deploy_android.result == 'success' && needs.deploy_ios.result == 'success' }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Comment and transition release issues
+        env:
+          DEPLOYMENT_STAGE: ${{ env.DEPLOYMENT_STAGE }}
+          DEPLOYMENT_LOG_URL: ${{ env.DEPLOYMENT_LOG_URL }}
+          JIRA_BASE_URL: ${{ vars.JIRA_BASE_URL || 'https://strnadi-status.atlassian.net' }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_PROJECT_KEYS: ${{ vars.JIRA_PROJECT_KEYS || 'APP' }}
+          JIRA_RELEASE_VERSION: ${{ env.JIRA_RELEASE_VERSION }}
+          JIRA_TARGET_STATUS: ${{ vars.JIRA_TEST_STATUS || 'To Test' }}
+          BRANCH_NAME: ${{ github.ref_name }}
+          JIRA_COMMENT_BODY: |
+            Release candidate ${{ github.ref_name }} was deployed successfully and is ready for QA testing.
+
+            Android track: ${{ env.GOOGLE_PLAY_TRACK }}
+            iOS target: TestFlight
+            Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash .github/scripts/release-jira.sh

--- a/.jira/config.yml
+++ b/.jira/config.yml
@@ -6,6 +6,7 @@ deployments:
     testing:
       - "android-testing"
       - "ios-testflight"
+      - "ios-testflight-external"
       - "test*"
     staging:
       - "staging"
@@ -14,5 +15,6 @@ deployments:
       - "pre-prod"
     production:
       - "android-production"
+      - "ios-app-store"
       - "production"
       - "prod*"

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -54,6 +54,20 @@ def resolved_release_status(options)
   release_status.empty? ? "completed" : release_status
 end
 
+def resolved_promote_from_track(options)
+  track = options[:from_track].to_s.strip
+  track = ENV["GOOGLE_PLAY_PROMOTE_FROM_TRACK"].to_s.strip if track.empty?
+  track = ENV["GOOGLE_PLAY_CLOSED_TRACK"].to_s.strip if track.empty?
+  track.empty? ? "alpha" : track
+end
+
+def resolved_promote_to_track(options)
+  track = options[:to_track].to_s.strip
+  track = ENV["GOOGLE_PLAY_PROMOTE_TO_TRACK"].to_s.strip if track.empty?
+  track = ENV["GOOGLE_PLAY_TRACK"].to_s.strip if track.empty?
+  track.empty? ? "beta" : track
+end
+
 def google_play_tracks_to_check(target_track)
   tracks = %w[internal alpha beta production]
   closed_track = ENV["GOOGLE_PLAY_CLOSED_TRACK"].to_s.strip
@@ -141,5 +155,30 @@ platform :android do
     track = ENV["GOOGLE_PLAY_CLOSED_TRACK"].to_s.strip
     track = "alpha" if track.empty?
     play(options.merge(track: track))
+  end
+
+  desc "Promote the active Google Play release from one track to another"
+  lane :promote do |options|
+    root = project_root
+    from_track = resolved_promote_from_track(options)
+    to_track = resolved_promote_to_track(options)
+    release_status = resolved_release_status(options)
+    json_key = ENV["SUPPLY_JSON_KEY"].to_s.strip
+    json_key = File.join(root, "android/play-store-service-account.json") if json_key.empty?
+
+    UI.user_error!("Missing Google Play service account JSON: #{json_key}") unless File.exist?(json_key)
+    UI.user_error!("Promotion source and target tracks must differ") if from_track == to_track
+
+    upload_to_play_store(
+      package_name: PACKAGE_NAME,
+      track: from_track,
+      track_promote_to: to_track,
+      track_promote_release_status: release_status,
+      json_key: json_key,
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true
+    )
   end
 end

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,13 +4,24 @@ GitHub Actions deploys the Flutter app with Fastlane from `.github/workflows/dep
 
 ## Behavior
 
-- Pushes to `main` deploy Android to the Google Play `internal` track and iOS to TestFlight.
-- Pushes to `release/**` deploy Android to the closed testing track and iOS to TestFlight.
+- Pushes to `main` run the `internal` stage: Android is uploaded to the Google Play `internal` track and iOS is uploaded to TestFlight.
+- Pushes to `release/**` run the `release_candidate` stage: Android is uploaded to the release-candidate Play track and iOS is uploaded to TestFlight.
+- Manual `external_beta` runs promote Android from the release-candidate track to the Google Play open testing track and distribute the already uploaded TestFlight build to the `External` group.
+- Manual `production` runs promote Android from open testing to production and submit the latest TestFlight build for App Store review with automatic release after approval.
 - Manual runs support `all`, `ios`, or `android`.
-- Manual Android runs accept `play_track`, such as `internal`, `alpha`, `beta`, or a custom closed-testing track name from Play Console.
+- Manual Android runs can override `play_track`, but normal release automation derives it from the selected deployment stage.
 - `build_number` defaults to the GitHub Actions run number so Android `versionCode` and iOS `CFBundleVersion` stay numeric.
 - `build_name` defaults to the version before `+` in `pubspec.yaml`.
 - Both platforms build with `--dart-define-from-file=build.env.json`.
+
+## Release Stages
+
+| Stage | Trigger | Android | iOS | Jira effect |
+| --- | --- | --- | --- | --- |
+| `internal` | Push to `main`, or manual run | Upload new AAB to `internal` | Upload new build to TestFlight | Comment linked Jira issue keys when present |
+| `release_candidate` | Push to `release/**`, or manual run | Upload new AAB to `GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK` | Upload new build to TestFlight | Comment all issues in the release `fixVersion` and transition them to `JIRA_TEST_STATUS` |
+| `external_beta` | Jira automation or manual run after all release issues pass QA | Promote from release-candidate track to `GOOGLE_PLAY_OPEN_BETA_TRACK` | Distribute existing build to TestFlight group `External` | Comment linked Jira issue keys when present |
+| `production` | Jira automation after seven days in external beta, or manual run | Promote from `GOOGLE_PLAY_OPEN_BETA_TRACK` to `production` | Submit existing TestFlight build for App Store review and automatic release | Comment linked Jira issue keys when present |
 
 ## Required GitHub Secrets
 
@@ -58,7 +69,28 @@ The iOS deploy job uses GitHub's `macos-26` runner so App Store Connect receives
 
 - `IOS_TEAM_ID`: Apple Developer Team ID. Defaults to `3GPTVJHVFN`.
 - `FLUTTER_VERSION`: Flutter SDK version. Defaults to `3.41.2`.
-- `GOOGLE_PLAY_CLOSED_TRACK`: Play Console closed-testing track for `release/**` pushes. Defaults to `alpha`.
+- `GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK`: Play Console track for release-candidate builds. Defaults to `GOOGLE_PLAY_CLOSED_TRACK`, then `alpha`.
+- `GOOGLE_PLAY_CLOSED_TRACK`: Legacy fallback for the release-candidate track. Defaults to `alpha`.
+- `GOOGLE_PLAY_OPEN_BETA_TRACK`: Play Console open testing track. Defaults to `beta`.
+- `JIRA_TEST_STATUS`: Jira status used after a release-candidate deploy. Defaults to `To Test`.
+- `IOS_USES_NON_EXEMPT_ENCRYPTION`: Set to `true` only if App Store export compliance requires it. Defaults to `false`.
+
+## Jira-Triggered Dispatch
+
+Jira automation can call the deployment workflow with GitHub's workflow dispatch API:
+
+```json
+{
+  "ref": "release/1.6.0",
+  "inputs": {
+    "platform": "all",
+    "deployment_stage": "external_beta",
+    "jira_release_version": "1.6.0"
+  }
+}
+```
+
+For production after a week in external beta, use the same request with `"deployment_stage": "production"`. If App Store Connect should submit a specific processed build, also pass `app_store_build_number`; otherwise Fastlane selects the latest build for the editable app version.
 
 ## Local Encoding Commands
 
@@ -82,6 +114,7 @@ cd android
 bundle exec fastlane play
 bundle exec fastlane internal
 bundle exec fastlane closed_beta
+bundle exec fastlane promote
 ```
 
 iOS:
@@ -89,5 +122,7 @@ iOS:
 ```sh
 cd ios
 bundle exec fastlane testflight
+bundle exec fastlane external_beta
+bundle exec fastlane app_store
 bundle exec fastlane beta
 ```

--- a/docs/jira-workflow.md
+++ b/docs/jira-workflow.md
@@ -12,10 +12,19 @@ This repository is configured for the `APP` Jira project on `strnadi-status.atla
 
 The `Branch and Jira Policy` workflow validates feature and release branch names on pushes and pull requests.
 
+## Jira Release Model
+
+- Every feature, story, task, and bug that will ship must have a Jira release in `Fix versions`.
+- The release name should match the Git branch version, for example Jira `fixVersion` `1.6.0` maps to `release/1.6.0`.
+- Use one Jira release task per app release when you want a single control issue for automation state. The recommended statuses for that release task are `Release Candidate`, `Open Beta`, and `Production Released`.
+- Add a `To Test` status to the `APP` project workflow for feature/story/task/bug issues. The deploy workflow will use `JIRA_TEST_STATUS` and defaults to `To Test`.
+- QA marks tested issues `Done`. If testing fails, QA moves the issue back to `In Progress` with a comment.
+
 ## Pull Requests
 
 - Feature branches should include the Jira key in the branch name and PR template.
 - Pull request titles must include the Jira key so GitHub for Jira can link the PR natively.
+- The Jira issue must have `Fix versions` set before it is merged into a `release/**` branch.
 - At least one feature branch commit subject must include the Jira key so GitHub for Jira can link builds and deployments.
 - Jira issue keys are detected from the branch, title, PR body, and commit subjects.
 - If `JIRA_USER_EMAIL` and `JIRA_API_TOKEN` are configured, the workflow verifies that detected Jira issues exist.
@@ -23,22 +32,77 @@ The `Branch and Jira Policy` workflow validates feature and release branch names
 
 ## Deployments
 
-- Push to `main`: deploys Android to the Play Console `internal` track and iOS to TestFlight.
-- Push to `release/**`: deploys Android to the closed testing track and iOS to TestFlight.
-- The closed testing track defaults to `alpha`; set the `GOOGLE_PLAY_CLOSED_TRACK` repository variable if your Play Console closed-testing track uses another name.
-- Manual deploys can override the Play track with the `play_track` workflow input.
+- Push to `main`: runs the `internal` deployment stage.
+- Push to `release/**`: runs the `release_candidate` deployment stage.
+- Manual or Jira-triggered `external_beta`: promotes Android to Google Play open testing and distributes iOS to TestFlight group `External`.
+- Manual or Jira-triggered `production`: promotes Android to Google Play production and submits the latest TestFlight build for App Store review with automatic release after approval.
+- The release-candidate track defaults to `alpha`; set `GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK` if your Play Console track uses another name.
+- The open beta track defaults to `beta`; set `GOOGLE_PLAY_OPEN_BETA_TRACK` if your Play Console open testing track uses another name.
 - The deploy workflow creates GitHub deployment events and status updates so Jira can show Android and iOS deployments in the Deployments view.
 - Deployment events use the deployed branch name as the GitHub deployment ref and pin the exact deployed commit SHA.
 - Android deployments use the `android-testing` environment unless the Play track is `production`, in which case they use `android-production`.
-- iOS TestFlight deployments use the `ios-testflight` environment.
+- iOS release-candidate TestFlight deployments use `ios-testflight`.
+- iOS external beta distribution uses `ios-testflight-external`.
+- iOS production submission uses `ios-app-store`.
 - Custom deployment environments are mapped for Jira in `.jira/config.yml`.
-- If a deploy branch contains a Jira issue key, the deploy workflow also comments on that Jira issue after successful Android and iOS uploads.
+- If a deploy branch contains a Jira issue key, the deploy workflow comments on that Jira issue after a successful platform deploy.
+- After both Android and iOS release-candidate deploys succeed, `.github/scripts/release-jira.sh` finds all issues with the release `fixVersion`, comments on them, and transitions them to `JIRA_TEST_STATUS`.
+
+## Jira Automation Rules
+
+Create these rules in the `APP` Jira project.
+
+### Notify Testers
+
+- Trigger: Issue transitioned to `To Test`.
+- Condition: Project is `APP`.
+- Action: Notify the QA/tester group with the issue key, summary, release, and GitHub workflow link from the latest issue comment.
+
+### Release To External Beta
+
+- Trigger: Issue transitioned.
+- Condition: The issue has at least one `Fix versions` value.
+- Lookup issues JQL: `project = APP AND fixVersion = "{{issue.fixVersions.first.name}}" AND issuetype in (Feature, Story, Task, Bug) AND statusCategory != Done`.
+- If the lookup result count is `0`, send a web request to GitHub:
+
+URL: `https://api.github.com/repos/Strnadi/Strnadi-Mobile-App/actions/workflows/deploy.yml/dispatches`
+
+Headers:
+
+- `Authorization: Bearer <GitHub workflow dispatch token>`
+- `Accept: application/vnd.github+json`
+- `Content-Type: application/json`
+
+```json
+{
+  "ref": "release/{{issue.fixVersions.first.name}}",
+  "inputs": {
+    "platform": "all",
+    "deployment_stage": "external_beta",
+    "jira_release_version": "{{issue.fixVersions.first.name}}"
+  }
+}
+```
+
+- Then transition the release task for that version to `Open Beta`, or comment on the release if you do not use release tasks.
+
+### Release To Production After Seven Days
+
+- Trigger: Scheduled, once per day.
+- JQL: `project = APP AND issuetype = Task AND status = "Open Beta" AND status CHANGED TO "Open Beta" BEFORE -7d`.
+- Action: Send the same GitHub workflow dispatch request with `"deployment_stage": "production"`.
+- Then transition the release task to `Production Released`.
+- If production was already released manually, transition the release task to `Production Released`; the scheduled rule will no longer match it.
+
+The Jira web request needs a GitHub token with permission to dispatch repository workflows for `Strnadi/Strnadi-Mobile-App`.
 
 ## Required GitHub Variables
 
 - `JIRA_BASE_URL`: defaults to `https://strnadi-status.atlassian.net`.
 - `JIRA_PROJECT_KEYS`: defaults to `APP`. Use comma-separated values like `APP,WEB` if this repo should accept multiple Jira projects.
-- `GOOGLE_PLAY_CLOSED_TRACK`: optional Play Console closed-testing track for `release/**` pushes. Defaults to `alpha`.
+- `JIRA_TEST_STATUS`: defaults to `To Test`.
+- `GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK`: optional Play Console release-candidate testing track. Defaults to `alpha`.
+- `GOOGLE_PLAY_OPEN_BETA_TRACK`: optional Play Console open testing track. Defaults to `beta`.
 
 ## Required GitHub Secrets for Jira Comments and Validation
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -49,8 +49,16 @@ def required_env(name)
   value
 end
 
+def optional_env(name)
+  ENV[name].to_s.strip
+end
+
 def shell_arg(key, value)
   "#{key}=#{Shellwords.escape(value.to_s)}"
+end
+
+def truthy_env?(name)
+  %w[1 true yes].include?(ENV[name].to_s.strip.downcase)
 end
 
 def app_store_connect_api_key_path
@@ -166,6 +174,81 @@ platform :ios do
       ipa: ipa_path,
       skip_waiting_for_build_processing: true
     )
+
+    if truthy_env?("TESTFLIGHT_DISTRIBUTE_EXTERNAL")
+      groups = ENV["TESTFLIGHT_GROUPS"].to_s.split(",").map(&:strip).reject(&:empty?)
+      UI.user_error!("TESTFLIGHT_GROUPS must name at least one group for external distribution") if groups.empty?
+
+      upload_to_testflight(
+        api_key: api_key,
+        distribute_only: true,
+        distribute_external: true,
+        notify_external_testers: truthy_env?("TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS"),
+        groups: groups,
+        app_version: build_name,
+        build_number: build_number
+      )
+    end
+  end
+
+  desc "Distribute the latest processed TestFlight build to the external tester group"
+  lane :external_beta do |options|
+    api_key = app_store_connect_api_key(
+      key_id: required_env("APP_STORE_CONNECT_API_KEY_ID"),
+      issuer_id: required_env("APP_STORE_CONNECT_API_ISSUER_ID"),
+      key_content: required_env("APP_STORE_CONNECT_API_KEY_BASE64"),
+      is_key_content_base64: true,
+      duration: 1200
+    )
+
+    build_name = resolved_build_name(options)
+    build_number = optional_env("TESTFLIGHT_BUILD_NUMBER")
+    groups = ENV["TESTFLIGHT_GROUPS"].to_s.split(",").map(&:strip).reject(&:empty?)
+    groups = ["External"] if groups.empty?
+
+    pilot_options = {
+      api_key: api_key,
+      distribute_only: true,
+      distribute_external: true,
+      notify_external_testers: truthy_env?("TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS"),
+      groups: groups,
+      app_version: build_name
+    }
+    pilot_options[:build_number] = build_number unless build_number.empty?
+
+    upload_to_testflight(pilot_options)
+  end
+
+  desc "Submit the latest TestFlight build for App Store review and automatic release after approval"
+  lane :app_store do
+    api_key = app_store_connect_api_key(
+      key_id: required_env("APP_STORE_CONNECT_API_KEY_ID"),
+      issuer_id: required_env("APP_STORE_CONNECT_API_ISSUER_ID"),
+      key_content: required_env("APP_STORE_CONNECT_API_KEY_BASE64"),
+      is_key_content_base64: true,
+      duration: 1200
+    )
+
+    deliver_options = {
+      api_key: api_key,
+      app_identifier: BUNDLE_IDENTIFIER,
+      submit_for_review: true,
+      automatic_release: true,
+      force: true,
+      skip_metadata: true,
+      skip_screenshots: true,
+      skip_binary_upload: true,
+      submission_information: {
+        export_compliance_uses_encryption: truthy_env?("IOS_USES_NON_EXEMPT_ENCRYPTION")
+      }
+    }
+
+    build_number = optional_env("APP_STORE_BUILD_NUMBER")
+    app_version = optional_env("APP_STORE_APP_VERSION")
+    deliver_options[:build_number] = build_number unless build_number.empty?
+    deliver_options[:app_version] = app_version unless app_version.empty?
+
+    upload_to_app_store(deliver_options)
   end
 
   lane :beta do |options|


### PR DESCRIPTION
This pull request introduces significant improvements to the deployment automation for both Android and iOS, focusing on more flexible release management, improved Jira integration, and environment-specific optimizations. The workflow now supports distinct deployment stages (internal, release candidate, external beta, production), conditional steps for promotion-only releases, and enhanced Jira automation for release tracking.

**Deployment Workflow Enhancements**

* Added a `deployment_stage` input to the workflow, supporting choices like internal, release_candidate, external_beta, and production, with environment variables and job steps conditioned on this value. This enables more granular control over deployment flows for different release stages. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L19-L23) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R84-R98) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L79-R140) [[4]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R168-R174) [[5]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R183-R190) [[6]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R202-R214) [[7]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L173-R236) [[8]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L184-R247) [[9]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L218-R289) [[10]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R299-R307) [[11]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R323) [[12]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R334) [[13]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R344-R372)

* Android: Added logic for "promote-only" releases (e.g., external beta, production) where the workflow skips building and only promotes an existing release between Play Console tracks. A new script restores only the Play Store service account for these cases. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R84-R98) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L79-R140) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R149) [[4]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R168-R174) [[5]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R183-R190) [[6]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R202-R214) [[7]](diffhunk://#diff-e294160586e725eb07b2115df4f35fcc643b972f375000827cdd6ee4684fc259R1-R16)

* iOS: Deployment environment, description, and production-environment flag are now set dynamically based on the deployment stage, supporting TestFlight (internal/external) and App Store releases. Build and signing steps are conditioned to run only for internal or release candidate stages. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L218-R289) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R299-R307) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R323) [[4]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R334) [[5]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R344-R372)

**Jira Integration Improvements**

* Added a new script `.github/scripts/release-jira.sh` to automatically find all Jira issues for the current release version, comment on them, and transition their status to "To Test" upon deployment. The script is robust to credentials and branch naming, and is only triggered for release candidates.

* Updated the pull request template to include a `Jira release / fixVersion` field, promoting better tracking of releases in Jira.

**Release Metadata and Inputs**

* Added new workflow inputs for TestFlight and App Store distribution (e.g., `testflight_groups`, `testflight_build_number`, `app_store_build_number`, `app_store_app_version`, `jira_release_version`) to allow more flexible and explicit control over release parameters.

**Other Improvements**

* Improved concurrency group naming to include deployment stage, preventing job collisions between different release environments.

* Updated job and environment descriptions to reflect the deployment stage for better traceability in GitHub Actions and deployment logs. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L79-R140) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L173-R236) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L184-R247) [[4]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L195-R258) [[5]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L218-R289)

These changes collectively make the deployment process more robust, auditable, and adaptable to different release workflows.