### PR TITLE
APP-12: feat: add click outside of search

### DIFF
--- a/lib/map/searchBar.dart
+++ b/lib/map/searchBar.dart
@@ -26,13 +26,24 @@ class SearchBarWidget extends StatefulWidget {
   const SearchBarWidget({required this.onLocationSelected, super.key});
 
   @override
-  State<SearchBarWidget> createState() => _SearchBarWidgetState();
+  State<SearchBarWidget> createState() => SearchBarWidgetState();
 }
 
-class _SearchBarWidgetState extends State<SearchBarWidget> {
+class SearchBarWidgetState extends State<SearchBarWidget> {
   final TextEditingController _controller = TextEditingController();
+  final FocusNode _focusNode = FocusNode();
   Timer? _debounce;
   List<_SearchResult> _results = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode.addListener(() {
+      if (!_focusNode.hasFocus) {
+        setState(() => _results = []);
+      }
+    });
+  }
 
   /// Determines if a prompt contains coordinates and extracts them
   /// Returns a LatLng object if valid coordinates are found, null otherwise
@@ -168,6 +179,11 @@ class _SearchBarWidgetState extends State<SearchBarWidget> {
     return parseCoordinatesFromPrompt(prompt) != null;
   }
 
+  void closeSearch() {
+    setState(() => _results = []);
+    _focusNode.unfocus();
+  }
+
   void _onSearchChanged(String query) {
     _debounce?.cancel();
     _debounce = Timer(const Duration(milliseconds: 300), () async {
@@ -215,13 +231,16 @@ class _SearchBarWidgetState extends State<SearchBarWidget> {
   @override
   void dispose() {
     _controller.dispose();
+    _focusNode.dispose();
     _debounce?.cancel();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return Material(
+    return TapRegion(
+      onTapOutside: (_) => closeSearch(),
+      child: Material(
       elevation: 6,
       borderRadius: BorderRadius.circular(12),
       child: Column(
@@ -229,6 +248,7 @@ class _SearchBarWidgetState extends State<SearchBarWidget> {
         children: [
           TextField(
             controller: _controller,
+            focusNode: _focusNode,
             onChanged: _onSearchChanged,
             decoration: InputDecoration(
               hintText: t('map.search.hint'),
@@ -240,12 +260,10 @@ class _SearchBarWidgetState extends State<SearchBarWidget> {
             ),
           ),
           if (_results.isNotEmpty)
-            Container(
-              decoration: const BoxDecoration(
-                color: Colors.white,
-                borderRadius:
-                    BorderRadius.vertical(bottom: Radius.circular(12)),
-              ),
+            Material(
+              color: Colors.white,
+              borderRadius:
+                  const BorderRadius.vertical(bottom: Radius.circular(12)),
               child: ListView.separated(
                 shrinkWrap: true,
                 itemCount: _results.length,
@@ -265,6 +283,7 @@ class _SearchBarWidgetState extends State<SearchBarWidget> {
               ),
             ),
         ],
+      ),
       ),
     );
   }


### PR DESCRIPTION
This pull request refactors the `SearchBarWidget` in `lib/map/searchBar.dart` to improve search result handling and user experience. The main changes include making the search bar close its results when focus is lost or when the user taps outside, managing focus with a dedicated `FocusNode`, and updating the widget structure for better interaction handling.

**Improvements to focus and search result management:**

* Added a `FocusNode` (`_focusNode`) to the `SearchBarWidgetState` to track focus changes and automatically clear search results when the search bar loses focus.
* Implemented a `closeSearch()` method to clear search results and unfocus the search bar, and called it when tapping outside the widget using a `TapRegion`. [[1]](diffhunk://#diff-9b16328a28f4bd323df4c970c56580bd412402c9c76beeb074eb08b8471a2282R182-R186) [[2]](diffhunk://#diff-9b16328a28f4bd323df4c970c56580bd412402c9c76beeb074eb08b8471a2282R234-R251)

**Widget structure and resource management:**

* Changed the widget tree to wrap the search bar in a `TapRegion` for outside-tap detection, and updated the search results dropdown to use a `Material` widget for consistent styling. [[1]](diffhunk://#diff-9b16328a28f4bd323df4c970c56580bd412402c9c76beeb074eb08b8471a2282R234-R251) [[2]](diffhunk://#diff-9b16328a28f4bd323df4c970c56580bd412402c9c76beeb074eb08b8471a2282L243-R266)
* Ensured proper disposal of the `FocusNode` in the `dispose()` method to prevent memory leaks.

**Code organization:**

* Renamed the state class from `_SearchBarWidgetState` to `SearchBarWidgetState` and updated its usage accordingly.