### PR TITLE
APP-28 Added version script

### DIFF
--- a/.github/scripts/sync-pubspec-version.sh
+++ b/.github/scripts/sync-pubspec-version.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+branch_name="${BRANCH_NAME:-${GITHUB_REF_NAME:-}}"
+deployment_stage="${DEPLOYMENT_STAGE:-}"
+output_file="${GITHUB_OUTPUT:-/dev/null}"
+version_changed=false
+release_version=""
+deploy_sha_output=""
+
+write_output() {
+  printf '%s=%s\n' "$1" "$2" >> "$output_file"
+}
+
+write_outputs() {
+  write_output version_changed "$version_changed"
+  write_output release_version "$release_version"
+  write_output deploy_sha "$deploy_sha_output"
+}
+
+deploy_sha() {
+  git rev-parse HEAD
+}
+
+if [[ "$branch_name" != release/* ]]; then
+  deploy_sha_output="$(deploy_sha)"
+  write_outputs
+  echo "Pubspec version sync skipped for branch '${branch_name}' and stage '${deployment_stage}'."
+  exit 0
+fi
+
+if [[ "$deployment_stage" != "internal" && "$deployment_stage" != "release_candidate" ]]; then
+  deploy_sha_output="$(deploy_sha)"
+  write_outputs
+  echo "Pubspec version sync skipped for release promotion stage '${deployment_stage}'."
+  exit 0
+fi
+
+release_ref="${branch_name#release/}"
+release_version="$release_ref"
+
+if [[ "$release_ref" =~ ^[A-Z][A-Z0-9]+-[0-9]+[-/](.+)$ ]]; then
+  release_version="${BASH_REMATCH[1]}"
+fi
+
+if [[ ! "$release_version" =~ ^[0-9]+(\.[0-9]+){1,3}([.-][A-Za-z0-9]+)*$ ]]; then
+  echo "::error::Could not derive a valid app version from release branch '${branch_name}'."
+  exit 1
+fi
+
+target_pubspec_version="${release_version}+${release_version}"
+current_pubspec_version="$(
+  sed -nE 's/^[[:space:]]*version:[[:space:]]*([^[:space:]]+).*$/\1/p' pubspec.yaml |
+    head -n 1
+)"
+
+if [[ "$current_pubspec_version" == "$target_pubspec_version" ]]; then
+  deploy_sha_output="$(deploy_sha)"
+  write_outputs
+  echo "pubspec.yaml already uses version ${target_pubspec_version}."
+  exit 0
+fi
+
+PUBSPEC_VERSION="$target_pubspec_version" perl -0pi -e 's/^version:.*$/version: $ENV{PUBSPEC_VERSION}/m' pubspec.yaml
+
+if git diff --quiet -- pubspec.yaml; then
+  deploy_sha_output="$(deploy_sha)"
+  write_outputs
+  echo "pubspec.yaml did not change."
+  exit 0
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git add pubspec.yaml
+git commit -m "Sync pubspec version to ${release_version} [skip ci]"
+git push origin "HEAD:${branch_name}"
+
+version_changed=true
+deploy_sha_output="$(deploy_sha)"
+write_outputs
+echo "Updated pubspec.yaml from ${current_pubspec_version} to ${target_pubspec_version}."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,18 +75,18 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write
   deployments: write
 
 env:
   BUILD_NAME: ${{ github.event.inputs.build_name }}
   BUILD_NUMBER: ${{ github.event.inputs.build_number || github.run_number }}
-  DEPLOYMENT_STAGE: ${{ github.event.inputs.deployment_stage || (startsWith(github.ref_name, 'release/') && 'release_candidate') || 'internal' }}
+  DEPLOYMENT_STAGE: ${{ github.event.inputs.deployment_stage || 'internal' }}
   DEPLOYMENT_LOG_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
   GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK: ${{ vars.GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK || vars.GOOGLE_PLAY_CLOSED_TRACK || 'alpha' }}
   GOOGLE_PLAY_OPEN_BETA_TRACK: ${{ vars.GOOGLE_PLAY_OPEN_BETA_TRACK || 'beta' }}
-  GOOGLE_PLAY_TRACK: ${{ github.event.inputs.play_track || (github.event.inputs.deployment_stage == 'production' && 'production') || (github.event.inputs.deployment_stage == 'external_beta' && (vars.GOOGLE_PLAY_OPEN_BETA_TRACK || 'beta')) || (github.event.inputs.deployment_stage == 'release_candidate' && (vars.GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK || vars.GOOGLE_PLAY_CLOSED_TRACK || 'alpha')) || (startsWith(github.ref_name, 'release/') && (vars.GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK || vars.GOOGLE_PLAY_CLOSED_TRACK || 'alpha')) || 'internal' }}
-  GOOGLE_PLAY_PROMOTE_FROM_TRACK: ${{ (github.event.inputs.deployment_stage == 'production' && (vars.GOOGLE_PLAY_OPEN_BETA_TRACK || 'beta')) || (github.event.inputs.deployment_stage == 'external_beta' && (vars.GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK || vars.GOOGLE_PLAY_CLOSED_TRACK || 'alpha')) || '' }}
+  GOOGLE_PLAY_TRACK: ${{ github.event.inputs.play_track || (github.event.inputs.deployment_stage == 'production' && 'production') || (github.event.inputs.deployment_stage == 'external_beta' && (vars.GOOGLE_PLAY_OPEN_BETA_TRACK || 'beta')) || (github.event.inputs.deployment_stage == 'release_candidate' && (vars.GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK || vars.GOOGLE_PLAY_CLOSED_TRACK || 'alpha')) || 'internal' }}
+  GOOGLE_PLAY_PROMOTE_FROM_TRACK: ${{ (github.event.inputs.deployment_stage == 'production' && (vars.GOOGLE_PLAY_OPEN_BETA_TRACK || 'beta')) || (github.event.inputs.deployment_stage == 'external_beta' && 'internal') || '' }}
   GOOGLE_PLAY_PROMOTE_TO_TRACK: ${{ github.event.inputs.play_track || (github.event.inputs.deployment_stage == 'production' && 'production') || (github.event.inputs.deployment_stage == 'external_beta' && (vars.GOOGLE_PLAY_OPEN_BETA_TRACK || 'beta')) || '' }}
   GOOGLE_PLAY_RELEASE_STATUS: ${{ github.event.inputs.release_status || 'completed' }}
   ANDROID_PROMOTE_ONLY: ${{ (github.event.inputs.deployment_stage == 'external_beta' || github.event.inputs.deployment_stage == 'production') && 'true' || 'false' }}
@@ -98,14 +98,40 @@ env:
   JIRA_RELEASE_VERSION: ${{ github.event.inputs.jira_release_version }}
 
 jobs:
-  deploy_android:
-    name: Deploy Android to Play Console
-    if: ${{ github.event_name == 'push' || github.event.inputs.platform == 'all' || github.event.inputs.platform == 'android' }}
+  sync_release_version:
+    name: Sync release version
     runs-on: ubuntu-latest
+    outputs:
+      deploy_sha: ${{ steps.sync.outputs.deploy_sha }}
+      release_version: ${{ steps.sync.outputs.release_version }}
+      version_changed: ${{ steps.sync.outputs.version_changed }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Sync pubspec.yaml with release branch
+        id: sync
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
+          DEPLOYMENT_STAGE: ${{ env.DEPLOYMENT_STAGE }}
+        run: bash .github/scripts/sync-pubspec-version.sh
+
+  deploy_android:
+    name: Deploy Android to Play Console
+    needs: sync_release_version
+    if: ${{ github.event_name == 'push' || github.event.inputs.platform == 'all' || github.event.inputs.platform == 'android' }}
+    runs-on: ubuntu-latest
+    env:
+      BUILD_NAME: ${{ github.event.inputs.build_name || needs.sync_release_version.outputs.release_version }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.sync_release_version.outputs.deploy_sha }}
 
       - name: Create Android GitHub deployment
         id: android_deployment
@@ -113,7 +139,7 @@ jobs:
         with:
           token: ${{ github.token }}
           ref: ${{ github.ref_name }}
-          sha: ${{ github.sha }}
+          sha: ${{ needs.sync_release_version.outputs.deploy_sha }}
           environment: ${{ env.GOOGLE_PLAY_TRACK == 'production' && 'android-production' || 'android-testing' }}
           task: 'deploy:android'
           initial-status: in_progress
@@ -264,12 +290,17 @@ jobs:
 
   deploy_ios:
     name: Deploy iOS to TestFlight
+    needs: sync_release_version
     if: ${{ github.event_name == 'push' || github.event.inputs.platform == 'all' || github.event.inputs.platform == 'ios' }}
     runs-on: macos-26
+    env:
+      BUILD_NAME: ${{ github.event.inputs.build_name || needs.sync_release_version.outputs.release_version }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.sync_release_version.outputs.deploy_sha }}
 
       - name: Create iOS GitHub deployment
         id: ios_deployment
@@ -277,7 +308,7 @@ jobs:
         with:
           token: ${{ github.token }}
           ref: ${{ github.ref_name }}
-          sha: ${{ github.sha }}
+          sha: ${{ needs.sync_release_version.outputs.deploy_sha }}
           environment: ${{ env.DEPLOYMENT_STAGE == 'production' && 'ios-app-store' || (env.DEPLOYMENT_STAGE == 'external_beta' && 'ios-testflight-external') || 'ios-testflight' }}
           task: 'deploy:ios'
           initial-status: in_progress
@@ -463,6 +494,7 @@ jobs:
     name: Mark Jira release ready for testing
     runs-on: ubuntu-latest
     needs:
+      - sync_release_version
       - deploy_android
       - deploy_ios
     if: ${{ always() && needs.deploy_android.result == 'success' && needs.deploy_ios.result == 'success' }}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,22 +5,67 @@ GitHub Actions deploys the Flutter app with Fastlane from `.github/workflows/dep
 ## Behavior
 
 - Pushes to `main` run the `internal` stage: Android is uploaded to the Google Play `internal` track and iOS is uploaded to TestFlight.
-- Pushes to `release/**` run the `release_candidate` stage: Android is uploaded to the release-candidate Play track and iOS is uploaded to TestFlight.
-- Manual `external_beta` runs promote Android from the release-candidate track to the Google Play open testing track and distribute the already uploaded TestFlight build to the `External` group.
+- Pushes to `release/**` also run the `internal` stage: Android is uploaded to the Google Play `internal` track and iOS is uploaded to TestFlight for tester validation.
+- Manual or Jira `external_beta` runs promote Android from the Google Play `internal` track to the open testing track and distribute the already uploaded TestFlight build to the `External` group.
 - Manual `production` runs promote Android from open testing to production and submit the latest TestFlight build for App Store review with automatic release after approval.
 - Manual runs support `all`, `ios`, or `android`.
 - Manual Android runs can override `play_track`, but normal release automation derives it from the selected deployment stage.
 - `build_number` defaults to the GitHub Actions run number so Android `versionCode` and iOS `CFBundleVersion` stay numeric.
-- `build_name` defaults to the version before `+` in `pubspec.yaml`.
+- On `release/**` internal or release-candidate builds, `build_name` is derived from the release branch name and `pubspec.yaml` is automatically synced and committed before deployment.
+- Outside release-candidate builds, `build_name` defaults to the version before `+` in `pubspec.yaml`.
 - Both platforms build with `--dart-define-from-file=build.env.json`.
+
+## Automatic Build Triggers
+
+The repository currently starts mobile deployment builds automatically in these cases:
+
+| Trigger | Workflow | What runs | Builds a new app binary? |
+| --- | --- | --- | --- |
+| Push to `main` | `Deploy Mobile Apps` | `internal` stage for Android and iOS | Yes |
+| Push to `release/**` | `Deploy Mobile Apps` | `internal` stage for Android and iOS | Yes |
+| Manual GitHub workflow dispatch with `deployment_stage = internal` | `Deploy Mobile Apps` | Internal Android/iOS deployment for selected platform(s) | Yes |
+| Manual or Jira workflow dispatch with `deployment_stage = release_candidate` | `Deploy Mobile Apps` | Release-candidate Android/iOS deployment for selected platform(s) | Yes |
+| Manual or Jira workflow dispatch with `deployment_stage = external_beta` | `Deploy Mobile Apps` | Android track promotion and TestFlight External distribution | No, promotes/distributes an existing build |
+| Manual or Jira workflow dispatch with `deployment_stage = production` | `Deploy Mobile Apps` | Android production promotion and App Store submission | No, promotes/submits an existing build |
+
+Other automatic workflows:
+
+| Trigger | Workflow | Purpose |
+| --- | --- | --- |
+| Pull request opened/edited/synchronized/reopened/ready for review | `Branch and Jira Policy` | Validates branch/Jira naming and comments Jira on PR open/reopen/ready. It does not build the app. |
+| Push to `feature/**` or `release/**` | `Branch and Jira Policy` | Validates branch naming. It does not build the app. |
+| GitHub Release published | `Update JSON on Release` | Updates the external APK download JSON over SSH. It does not build the app. |
+
+## Release Version Sync
+
+Before an `internal` or `release_candidate` deployment from a `release/**` branch, the workflow runs `.github/scripts/sync-pubspec-version.sh`.
+
+The script derives the app version from the branch name:
+
+- `release/1.7.0` -> `1.7.0`
+- `release/APP-123-1.7.0` -> `1.7.0`
+
+It then rewrites `pubspec.yaml` to:
+
+```yaml
+version: 1.7.0+1.7.0
+```
+
+If `pubspec.yaml` changed, the workflow commits the update back to the release branch with a commit like:
+
+```text
+Sync pubspec version to 1.7.0 [skip ci]
+```
+
+The Android and iOS deploy jobs then check out that synced commit and set `BUILD_NAME` to the derived release version, so Android `versionName` and iOS `CFBundleShortVersionString` match the release branch. `BUILD_NUMBER` still comes from GitHub Actions run number unless manually overridden.
 
 ## Release Stages
 
 | Stage | Trigger | Android | iOS | Jira effect |
 | --- | --- | --- | --- | --- |
-| `internal` | Push to `main`, or manual run | Upload new AAB to `internal` | Upload new build to TestFlight | Comment linked Jira issue keys when present |
-| `release_candidate` | Push to `release/**`, or manual run | Upload new AAB to `GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK` | Upload new build to TestFlight | Comment all issues in the release `fixVersion` and transition them to `JIRA_TEST_STATUS` |
-| `external_beta` | Jira automation or manual run after all release issues pass QA | Promote from release-candidate track to `GOOGLE_PLAY_OPEN_BETA_TRACK` | Distribute existing build to TestFlight group `External` | Comment linked Jira issue keys when present |
+| `internal` | Push to `main`, push to `release/**`, or manual run | Upload new AAB to `internal` | Upload new build to TestFlight | Comment linked Jira issue keys when present |
+| `release_candidate` | Manual or Jira dispatch only | Upload new AAB to `GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK` | Upload new build to TestFlight | Comment all issues in the release `fixVersion` and transition them to `JIRA_TEST_STATUS` |
+| `external_beta` | Jira version release automation or manual run after testers approve the version | Promote from `internal` to `GOOGLE_PLAY_OPEN_BETA_TRACK` | Distribute existing build to TestFlight group `External` | Comment linked Jira issue keys when present |
 | `production` | Jira automation after seven days in external beta, or manual run | Promote from `GOOGLE_PLAY_OPEN_BETA_TRACK` to `production` | Submit existing TestFlight build for App Store review and automatic release | Comment linked Jira issue keys when present |
 
 ## Required GitHub Secrets


### PR DESCRIPTION
This pull request introduces an automated release version synchronization step to the deployment workflow for mobile apps. On `release/**` branches, before deploying, the workflow now ensures that the `pubspec.yaml` version is automatically updated to match the release branch name, and, if necessary, commits and pushes this change. The Android and iOS deploy jobs then build and deploy from this synced commit, ensuring consistent versioning across releases. Documentation has been updated to clarify this new behavior and to better explain workflow triggers and versioning.

**Release version synchronization automation:**

* Added `.github/scripts/sync-pubspec-version.sh` to automatically derive the app version from the `release/**` branch name, update `pubspec.yaml`, and commit/push the change if needed.
* Introduced a new `sync_release_version` job in `.github/workflows/deploy.yml` that runs before Android/iOS deploy jobs; these jobs now depend on and use the synced commit and derived version for deployment. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R101-R142) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R293-R311) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R497)

**Workflow and environment improvements:**

* Updated workflow environment variables and job dependencies to ensure the correct commit and version are used for deployments, and fixed the logic for Play Store track promotion in `deploy.yml`. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L78-R89) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R101-R142)

**Documentation updates:**

* Expanded and clarified `docs/deployment.md` to document the new version sync step, build triggers, and deployment behaviors for all release stages.