### PR TITLE
APP-28 Better tracks on appstore

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,12 +49,12 @@ on:
         required: false
         type: string
       testflight_groups:
-        description: Comma-separated TestFlight external groups for external beta.
+        description: Optional comma-separated TestFlight groups for Open Beta distribution.
         required: false
         type: string
-        default: External
+        default: open_beta
       testflight_build_number:
-        description: Optional existing TestFlight build number to distribute externally.
+        description: Optional existing TestFlight build number to distribute to Open Beta.
         required: false
         type: string
       app_store_build_number:
@@ -90,7 +90,8 @@ env:
   GOOGLE_PLAY_PROMOTE_TO_TRACK: ${{ github.event.inputs.play_track || (github.event.inputs.deployment_stage == 'production' && 'production') || (github.event.inputs.deployment_stage == 'external_beta' && (vars.GOOGLE_PLAY_OPEN_BETA_TRACK || 'beta')) || '' }}
   GOOGLE_PLAY_RELEASE_STATUS: ${{ github.event.inputs.release_status || 'completed' }}
   ANDROID_PROMOTE_ONLY: ${{ (github.event.inputs.deployment_stage == 'external_beta' || github.event.inputs.deployment_stage == 'production') && 'true' || 'false' }}
-  TESTFLIGHT_GROUPS: ${{ github.event.inputs.testflight_groups || 'External' }}
+  TESTFLIGHT_CLOSED_BETA_GROUPS: ${{ vars.TESTFLIGHT_CLOSED_BETA_GROUPS || 'closed_beta' }}
+  TESTFLIGHT_OPEN_BETA_GROUPS: ${{ github.event.inputs.testflight_groups || vars.TESTFLIGHT_OPEN_BETA_GROUPS || 'open_beta' }}
   TESTFLIGHT_BUILD_NUMBER: ${{ github.event.inputs.testflight_build_number }}
   TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: "true"
   APP_STORE_BUILD_NUMBER: ${{ github.event.inputs.app_store_build_number }}
@@ -309,7 +310,7 @@ jobs:
           token: ${{ github.token }}
           ref: ${{ github.ref_name }}
           sha: ${{ needs.sync_release_version.outputs.deploy_sha }}
-          environment: ${{ env.DEPLOYMENT_STAGE == 'production' && 'ios-app-store' || (env.DEPLOYMENT_STAGE == 'external_beta' && 'ios-testflight-external') || 'ios-testflight' }}
+          environment: ${{ env.DEPLOYMENT_STAGE == 'production' && 'ios-app-store' || (env.DEPLOYMENT_STAGE == 'external_beta' && 'ios-testflight-open-beta') || 'ios-testflight' }}
           task: 'deploy:ios'
           initial-status: in_progress
           log-url: ${{ env.DEPLOYMENT_LOG_URL }}
@@ -399,7 +400,7 @@ jobs:
         working-directory: ios
         run: bundle exec pod install
 
-      - name: Deploy iOS build to TestFlight
+      - name: Deploy iOS build to closed_beta TestFlight group
         if: ${{ env.DEPLOYMENT_STAGE == 'internal' || env.DEPLOYMENT_STAGE == 'release_candidate' }}
         working-directory: ios
         env:
@@ -407,18 +408,23 @@ jobs:
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
           IOS_TEAM_ID: ${{ vars.IOS_TEAM_ID || '3GPTVJHVFN' }}
+          TESTFLIGHT_GROUPS: ${{ env.TESTFLIGHT_CLOSED_BETA_GROUPS }}
+          TESTFLIGHT_DISTRIBUTE_EXTERNAL: "true"
+          TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: ${{ env.TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS }}
         run: |
           mkdir -p ../build/ios
           set -o pipefail
           bundle exec fastlane testflight --verbose 2>&1 | tee ../build/ios/fastlane-testflight.log
 
-      - name: Distribute iOS build to external TestFlight group
+      - name: Distribute iOS build to open_beta TestFlight group
         if: ${{ env.DEPLOYMENT_STAGE == 'external_beta' }}
         working-directory: ios
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+          TESTFLIGHT_GROUPS: ${{ env.TESTFLIGHT_OPEN_BETA_GROUPS }}
+          TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS: ${{ env.TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS }}
         run: |
           mkdir -p ../build/ios
           set -o pipefail
@@ -460,7 +466,7 @@ jobs:
           token: ${{ github.token }}
           deployment-id: ${{ steps.ios_deployment.outputs.deployment_id }}
           state: failure
-          environment: ${{ env.DEPLOYMENT_STAGE == 'production' && 'ios-app-store' || (env.DEPLOYMENT_STAGE == 'external_beta' && 'ios-testflight-external') || 'ios-testflight' }}
+          environment: ${{ env.DEPLOYMENT_STAGE == 'production' && 'ios-app-store' || (env.DEPLOYMENT_STAGE == 'external_beta' && 'ios-testflight-open-beta') || 'ios-testflight' }}
           log-url: ${{ env.DEPLOYMENT_LOG_URL }}
           description: iOS ${{ env.DEPLOYMENT_STAGE }} deployment failed.
 
@@ -471,7 +477,7 @@ jobs:
           token: ${{ github.token }}
           deployment-id: ${{ steps.ios_deployment.outputs.deployment_id }}
           state: success
-          environment: ${{ env.DEPLOYMENT_STAGE == 'production' && 'ios-app-store' || (env.DEPLOYMENT_STAGE == 'external_beta' && 'ios-testflight-external') || 'ios-testflight' }}
+          environment: ${{ env.DEPLOYMENT_STAGE == 'production' && 'ios-app-store' || (env.DEPLOYMENT_STAGE == 'external_beta' && 'ios-testflight-open-beta') || 'ios-testflight' }}
           log-url: ${{ env.DEPLOYMENT_LOG_URL }}
           description: iOS ${{ env.DEPLOYMENT_STAGE }} deployment completed.
 

--- a/.jira/config.yml
+++ b/.jira/config.yml
@@ -6,7 +6,7 @@ deployments:
     testing:
       - "android-testing"
       - "ios-testflight"
-      - "ios-testflight-external"
+      - "ios-testflight-open-beta"
       - "test*"
     staging:
       - "staging"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,9 +4,9 @@ GitHub Actions deploys the Flutter app with Fastlane from `.github/workflows/dep
 
 ## Behavior
 
-- Pushes to `main` run the `internal` stage: Android is uploaded to the Google Play `internal` track and iOS is uploaded to TestFlight.
-- Pushes to `release/**` also run the `internal` stage: Android is uploaded to the Google Play `internal` track and iOS is uploaded to TestFlight for tester validation.
-- Manual or Jira `external_beta` runs promote Android from the Google Play `internal` track to the open testing track and distribute the already uploaded TestFlight build to the `External` group.
+- Pushes to `main` run the `internal` stage: Android is uploaded to the Google Play `internal` track and iOS is uploaded to the TestFlight `closed_beta` group.
+- Pushes to `release/**` also run the `internal` stage: Android is uploaded to the Google Play `internal` track and iOS is uploaded to the TestFlight `closed_beta` group for tester validation.
+- Manual or Jira `external_beta` runs promote Android from the Google Play `internal` track to the open testing track and distribute the already uploaded TestFlight build to the `open_beta` group.
 - Manual `production` runs promote Android from open testing to production and submit the latest TestFlight build for App Store review with automatic release after approval.
 - Manual runs support `all`, `ios`, or `android`.
 - Manual Android runs can override `play_track`, but normal release automation derives it from the selected deployment stage.
@@ -25,7 +25,7 @@ The repository currently starts mobile deployment builds automatically in these 
 | Push to `release/**` | `Deploy Mobile Apps` | `internal` stage for Android and iOS | Yes |
 | Manual GitHub workflow dispatch with `deployment_stage = internal` | `Deploy Mobile Apps` | Internal Android/iOS deployment for selected platform(s) | Yes |
 | Manual or Jira workflow dispatch with `deployment_stage = release_candidate` | `Deploy Mobile Apps` | Release-candidate Android/iOS deployment for selected platform(s) | Yes |
-| Manual or Jira workflow dispatch with `deployment_stage = external_beta` | `Deploy Mobile Apps` | Android track promotion and TestFlight External distribution | No, promotes/distributes an existing build |
+| Manual or Jira workflow dispatch with `deployment_stage = external_beta` | `Deploy Mobile Apps` | Android track promotion and TestFlight `open_beta` distribution | No, promotes/distributes an existing build |
 | Manual or Jira workflow dispatch with `deployment_stage = production` | `Deploy Mobile Apps` | Android production promotion and App Store submission | No, promotes/submits an existing build |
 
 Other automatic workflows:
@@ -63,9 +63,9 @@ The Android and iOS deploy jobs then check out that synced commit and set `BUILD
 
 | Stage | Trigger | Android | iOS | Jira effect |
 | --- | --- | --- | --- | --- |
-| `internal` | Push to `main`, push to `release/**`, or manual run | Upload new AAB to `internal` | Upload new build to TestFlight | Comment linked Jira issue keys when present |
-| `release_candidate` | Manual or Jira dispatch only | Upload new AAB to `GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK` | Upload new build to TestFlight | Comment all issues in the release `fixVersion` and transition them to `JIRA_TEST_STATUS` |
-| `external_beta` | Jira version release automation or manual run after testers approve the version | Promote from `internal` to `GOOGLE_PLAY_OPEN_BETA_TRACK` | Distribute existing build to TestFlight group `External` | Comment linked Jira issue keys when present |
+| `internal` | Push to `main`, push to `release/**`, or manual run | Upload new AAB to `internal` | Upload new build to TestFlight group `closed_beta` | Comment linked Jira issue keys when present |
+| `release_candidate` | Manual or Jira dispatch only | Upload new AAB to `GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK` | Upload new build to TestFlight group `closed_beta` | Comment all issues in the release `fixVersion` and transition them to `JIRA_TEST_STATUS` |
+| `external_beta` | Jira version release automation or manual run after testers approve the version | Promote from `internal` to `GOOGLE_PLAY_OPEN_BETA_TRACK` | Distribute existing build to TestFlight group `open_beta` | Comment linked Jira issue keys when present |
 | `production` | Jira automation after seven days in external beta, or manual run | Promote from `GOOGLE_PLAY_OPEN_BETA_TRACK` to `production` | Submit existing TestFlight build for App Store review and automatic release | Comment linked Jira issue keys when present |
 
 ## Required GitHub Secrets
@@ -117,6 +117,8 @@ The iOS deploy job uses GitHub's `macos-26` runner so App Store Connect receives
 - `GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK`: Play Console track for release-candidate builds. Defaults to `GOOGLE_PLAY_CLOSED_TRACK`, then `alpha`.
 - `GOOGLE_PLAY_CLOSED_TRACK`: Legacy fallback for the release-candidate track. Defaults to `alpha`.
 - `GOOGLE_PLAY_OPEN_BETA_TRACK`: Play Console open testing track. Defaults to `beta`.
+- `TESTFLIGHT_CLOSED_BETA_GROUPS`: Comma-separated TestFlight groups for new internal and release-candidate iOS builds. Defaults to `closed_beta`.
+- `TESTFLIGHT_OPEN_BETA_GROUPS`: Comma-separated TestFlight groups for Open Beta distribution. Defaults to `open_beta`; manual workflow input `testflight_groups` can override it for one run.
 - `JIRA_TEST_STATUS`: Jira status used after a release-candidate deploy. Defaults to `To Test`.
 - `IOS_USES_NON_EXEMPT_ENCRYPTION`: Set to `true` only if App Store export compliance requires it. Defaults to `false`.
 

--- a/docs/jira-workflow.md
+++ b/docs/jira-workflow.md
@@ -33,8 +33,8 @@ The `Branch and Jira Policy` workflow validates feature and release branch names
 ## Deployments
 
 - Push to `main`: runs the `internal` deployment stage.
-- Push to `release/**`: runs the `release_candidate` deployment stage.
-- Manual or Jira-triggered `external_beta`: promotes Android to Google Play open testing and distributes iOS to TestFlight group `External`.
+- Push to `release/**`: runs the `internal` deployment stage.
+- Manual or Jira-triggered `external_beta`: promotes Android to Google Play open testing and distributes iOS to TestFlight group `open_beta`.
 - Manual or Jira-triggered `production`: promotes Android to Google Play production and submits the latest TestFlight build for App Store review with automatic release after approval.
 - The release-candidate track defaults to `alpha`; set `GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK` if your Play Console track uses another name.
 - The open beta track defaults to `beta`; set `GOOGLE_PLAY_OPEN_BETA_TRACK` if your Play Console open testing track uses another name.
@@ -42,7 +42,7 @@ The `Branch and Jira Policy` workflow validates feature and release branch names
 - Deployment events use the deployed branch name as the GitHub deployment ref and pin the exact deployed commit SHA.
 - Android deployments use the `android-testing` environment unless the Play track is `production`, in which case they use `android-production`.
 - iOS release-candidate TestFlight deployments use `ios-testflight`.
-- iOS external beta distribution uses `ios-testflight-external`.
+- iOS open beta distribution uses `ios-testflight-open-beta`.
 - iOS production submission uses `ios-app-store`.
 - Custom deployment environments are mapped for Jira in `.jira/config.yml`.
 - If a deploy branch contains a Jira issue key, the deploy workflow comments on that Jira issue after a successful platform deploy.
@@ -58,7 +58,7 @@ Create these rules in the `APP` Jira project.
 - Condition: Project is `APP`.
 - Action: Notify the QA/tester group with the issue key, summary, release, and GitHub workflow link from the latest issue comment.
 
-### Release To External Beta
+### Release To Open Beta
 
 - Trigger: Issue transitioned.
 - Condition: The issue has at least one `Fix versions` value.
@@ -103,6 +103,8 @@ The Jira web request needs a GitHub token with permission to dispatch repository
 - `JIRA_TEST_STATUS`: defaults to `To Test`.
 - `GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK`: optional Play Console release-candidate testing track. Defaults to `alpha`.
 - `GOOGLE_PLAY_OPEN_BETA_TRACK`: optional Play Console open testing track. Defaults to `beta`.
+- `TESTFLIGHT_CLOSED_BETA_GROUPS`: optional comma-separated TestFlight groups for new internal and release-candidate iOS builds. Defaults to `closed_beta`.
+- `TESTFLIGHT_OPEN_BETA_GROUPS`: optional comma-separated TestFlight groups for Open Beta distribution. Defaults to `open_beta`.
 
 ## Required GitHub Secrets for Jira Comments and Validation
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -61,6 +61,10 @@ def truthy_env?(name)
   %w[1 true yes].include?(ENV[name].to_s.strip.downcase)
 end
 
+def env_list(name)
+  ENV[name].to_s.split(",").map(&:strip).reject(&:empty?)
+end
+
 def app_store_connect_api_key_path
   key_id = required_env("APP_STORE_CONNECT_API_KEY_ID")
   key_base64 = required_env("APP_STORE_CONNECT_API_KEY_BASE64")
@@ -169,29 +173,25 @@ platform :ios do
       ].join(" ")
     )
 
-    upload_to_testflight(
+    groups = env_list("TESTFLIGHT_GROUPS")
+    pilot_options = {
       api_key: api_key,
       ipa: ipa_path,
-      skip_waiting_for_build_processing: true
-    )
+      skip_waiting_for_build_processing: groups.empty?
+    }
 
-    if truthy_env?("TESTFLIGHT_DISTRIBUTE_EXTERNAL")
-      groups = ENV["TESTFLIGHT_GROUPS"].to_s.split(",").map(&:strip).reject(&:empty?)
-      UI.user_error!("TESTFLIGHT_GROUPS must name at least one group for external distribution") if groups.empty?
-
-      upload_to_testflight(
-        api_key: api_key,
-        distribute_only: true,
-        distribute_external: true,
+    unless groups.empty?
+      pilot_options.merge!(
+        distribute_external: truthy_env?("TESTFLIGHT_DISTRIBUTE_EXTERNAL"),
         notify_external_testers: truthy_env?("TESTFLIGHT_NOTIFY_EXTERNAL_TESTERS"),
-        groups: groups,
-        app_version: build_name,
-        build_number: build_number
+        groups: groups
       )
     end
+
+    upload_to_testflight(pilot_options)
   end
 
-  desc "Distribute the latest processed TestFlight build to the external tester group"
+  desc "Distribute the latest processed TestFlight build to the open_beta tester group"
   lane :external_beta do |options|
     api_key = app_store_connect_api_key(
       key_id: required_env("APP_STORE_CONNECT_API_KEY_ID"),
@@ -203,8 +203,8 @@ platform :ios do
 
     build_name = resolved_build_name(options)
     build_number = optional_env("TESTFLIGHT_BUILD_NUMBER")
-    groups = ENV["TESTFLIGHT_GROUPS"].to_s.split(",").map(&:strip).reject(&:empty?)
-    groups = ["External"] if groups.empty?
+    groups = env_list("TESTFLIGHT_GROUPS")
+    groups = ["open_beta"] if groups.empty?
 
     pilot_options = {
       api_key: api_key,


### PR DESCRIPTION
This pull request updates the mobile deployment workflow to clarify and standardize the use of TestFlight groups for iOS deployments, distinguishing between `closed_beta` and `open_beta` groups. It updates workflow logic, documentation, and Fastlane scripts to consistently use these group names and environment variables, replacing the previous generic or ambiguous terms like `External`. This improves clarity for both automation and team communication about which testers receive which builds.

**Workflow and Environment Variable Updates:**

* The GitHub Actions workflow now uses explicit `TESTFLIGHT_CLOSED_BETA_GROUPS` and `TESTFLIGHT_OPEN_BETA_GROUPS` environment variables, defaulting to `closed_beta` and `open_beta` respectively, for iOS internal/release-candidate and open beta distributions.
* Deployment steps and environment mappings have been updated to reference `open_beta` and `closed_beta` groups and environments, replacing previous references to `External` or `ios-testflight-external`. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L402-R427) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L312-R313) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L463-R469) [[4]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L474-R480) [[5]](diffhunk://#diff-da772bd699d346dab3c847147e456fd25c5e5079e22509539bfa84a423f30bc0L9-R9)

**Documentation Improvements:**

* All references in the documentation to "External" TestFlight groups have been replaced with "open_beta", and internal/release-candidate groups are clarified as "closed_beta". This affects deployment behavior tables, workflow descriptions, and required variable documentation. [[1]](diffhunk://#diff-7f6254f34e124b6ff67f63aacb73b5252aa8e2b8afe712f48cdd3b32a24f908cL7-R9) [[2]](diffhunk://#diff-7f6254f34e124b6ff67f63aacb73b5252aa8e2b8afe712f48cdd3b32a24f908cL28-R28) [[3]](diffhunk://#diff-7f6254f34e124b6ff67f63aacb73b5252aa8e2b8afe712f48cdd3b32a24f908cL66-R68) [[4]](diffhunk://#diff-7f6254f34e124b6ff67f63aacb73b5252aa8e2b8afe712f48cdd3b32a24f908cR120-R121) [[5]](diffhunk://#diff-c7d91a28f5dbe3a0d8b265f1f62bdeedb6d5f7d62ad040cce8504984d1e05f28L36-R45) [[6]](diffhunk://#diff-c7d91a28f5dbe3a0d8b265f1f62bdeedb6d5f7d62ad040cce8504984d1e05f28L61-R61) [[7]](diffhunk://#diff-c7d91a28f5dbe3a0d8b265f1f62bdeedb6d5f7d62ad040cce8504984d1e05f28R106-R107)

**Fastlane Script Enhancements:**

* The `ios/fastlane/Fastfile` now uses a helper method `env_list` to parse group lists from environment variables, and consistently applies the correct group for each deployment stage. The logic for distributing builds to TestFlight groups is streamlined and clarified, with improved error handling and defaults. [[1]](diffhunk://#diff-96a113f9048a44bf631e40227acc27a302b3daa91b60217ad3a7ff91fa6973deR64-R67) [[2]](diffhunk://#diff-96a113f9048a44bf631e40227acc27a302b3daa91b60217ad3a7ff91fa6973deL172-R194) [[3]](diffhunk://#diff-96a113f9048a44bf631e40227acc27a302b3daa91b60217ad3a7ff91fa6973deL206-R207)

These changes make the deployment process more predictable, configurable, and easier to understand for both engineers and QA/testers.