### PR TITLE
APP-28 Fixed pubspec sync

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,10 +108,49 @@ jobs:
       version_changed: ${{ steps.sync.outputs.version_changed }}
 
     steps:
+      - name: Decode release sync app private key
+        id: release_sync_private_key
+        if: ${{ startsWith(github.ref_name, 'release/') && (env.DEPLOYMENT_STAGE == 'internal' || env.DEPLOYMENT_STAGE == 'release_candidate') }}
+        env:
+          RELEASE_SYNC_APP_CLIENT_ID: ${{ vars.RELEASE_SYNC_APP_CLIENT_ID }}
+          RELEASE_SYNC_APP_PRIVATE_KEY_BASE64: ${{ secrets.RELEASE_SYNC_APP_PRIVATE_KEY }}
+        run: |
+          if [[ -z "$RELEASE_SYNC_APP_CLIENT_ID" ]]; then
+            echo "::error::Missing RELEASE_SYNC_APP_CLIENT_ID repository variable."
+            exit 1
+          fi
+
+          if [[ -z "$RELEASE_SYNC_APP_PRIVATE_KEY_BASE64" ]]; then
+            echo "::error::Missing RELEASE_SYNC_APP_PRIVATE_KEY secret. Store the GitHub App private key as base64."
+            exit 1
+          fi
+
+          private_key="$(
+            printf '%s' "$RELEASE_SYNC_APP_PRIVATE_KEY_BASE64" |
+              base64 -d |
+              awk 'BEGIN { ORS = "\\n" } { print }' |
+              sed 's/\\n$//'
+          )"
+
+          echo "::add-mask::$private_key"
+          printf 'private-key=%s\n' "$private_key" >> "$GITHUB_OUTPUT"
+
+      - name: Create release sync app token
+        id: release_sync_app_token
+        if: ${{ startsWith(github.ref_name, 'release/') && (env.DEPLOYMENT_STAGE == 'internal' || env.DEPLOYMENT_STAGE == 'release_candidate') }}
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_SYNC_APP_CLIENT_ID }}
+          private-key: ${{ steps.release_sync_private_key.outputs.private-key }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
+          token: ${{ steps.release_sync_app_token.outputs.token || github.token }}
 
       - name: Sync pubspec.yaml with release branch
         id: sync

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -59,6 +59,8 @@ Sync pubspec version to 1.7.0 [skip ci]
 
 The Android and iOS deploy jobs then check out that synced commit and set `BUILD_NAME` to the derived release version, so Android `versionName` and iOS `CFBundleShortVersionString` match the release branch. `BUILD_NUMBER` still comes from GitHub Actions run number unless manually overridden.
 
+The release version sync push is done with a GitHub App installation token. The GitHub App must be installed on this repository, have `Contents: Read and write`, and be added to the `release/**` ruleset bypass list with `Always` bypass.
+
 ## Release Stages
 
 | Stage | Trigger | Android | iOS | Jira effect |
@@ -75,6 +77,7 @@ Create these repository secrets before running the workflow.
 Shared:
 
 - `BUILD_ENV_JSON_BASE64`: Base64-encoded `build.env.json`.
+- `RELEASE_SYNC_APP_PRIVATE_KEY`: Base64-encoded private key PEM for the GitHub App allowed to bypass the `release/**` ruleset and commit the synced `pubspec.yaml` version.
 
 Android:
 
@@ -114,6 +117,7 @@ The iOS deploy job uses GitHub's `macos-26` runner so App Store Connect receives
 
 - `IOS_TEAM_ID`: Apple Developer Team ID. Defaults to `3GPTVJHVFN`.
 - `FLUTTER_VERSION`: Flutter SDK version. Defaults to `3.41.2`.
+- `RELEASE_SYNC_APP_CLIENT_ID`: Client ID of the GitHub App used to bypass release branch rulesets for automatic `pubspec.yaml` version sync.
 - `GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK`: Play Console track for release-candidate builds. Defaults to `GOOGLE_PLAY_CLOSED_TRACK`, then `alpha`.
 - `GOOGLE_PLAY_CLOSED_TRACK`: Legacy fallback for the release-candidate track. Defaults to `alpha`.
 - `GOOGLE_PLAY_OPEN_BETA_TRACK`: Play Console open testing track. Defaults to `beta`.
@@ -148,6 +152,7 @@ base64 -i build.env.json | pbcopy
 base64 -i android/strnadi-release-key.jks | pbcopy
 base64 -i play-store-service-account.json | pbcopy
 base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy
+base64 -i release-sync-app.private-key.pem | pbcopy
 base64 -i ios_distribution.p12 | pbcopy
 base64 -i Strnadi_AppStore.mobileprovision | pbcopy
 ```

--- a/docs/jira-workflow.md
+++ b/docs/jira-workflow.md
@@ -101,6 +101,7 @@ The Jira web request needs a GitHub token with permission to dispatch repository
 - `JIRA_BASE_URL`: defaults to `https://strnadi-status.atlassian.net`.
 - `JIRA_PROJECT_KEYS`: defaults to `APP`. Use comma-separated values like `APP,WEB` if this repo should accept multiple Jira projects.
 - `JIRA_TEST_STATUS`: defaults to `To Test`.
+- `RELEASE_SYNC_APP_CLIENT_ID`: GitHub App Client ID used for release branch version sync bypass.
 - `GOOGLE_PLAY_RELEASE_CANDIDATE_TRACK`: optional Play Console release-candidate testing track. Defaults to `alpha`.
 - `GOOGLE_PLAY_OPEN_BETA_TRACK`: optional Play Console open testing track. Defaults to `beta`.
 - `TESTFLIGHT_CLOSED_BETA_GROUPS`: optional comma-separated TestFlight groups for new internal and release-candidate iOS builds. Defaults to `closed_beta`.


### PR DESCRIPTION
This pull request enhances the release branch deployment workflow by introducing a GitHub App for secure and automated version synchronization, and updates the documentation to reflect the new requirements. The most important changes are summarized below.

**Workflow Improvements:**

* Added steps to the `.github/workflows/deploy.yml` workflow to decode a base64-encoded GitHub App private key and generate an installation token for pushing synced version changes to release branches, ensuring compliance with stricter branch protection rules.

**Documentation Updates:**

* Updated `docs/deployment.md` to explain that the release version sync push is now performed using a GitHub App installation token, and clarified the required permissions and ruleset bypass settings for the app.
* Documented the new required repository secret `RELEASE_SYNC_APP_PRIVATE_KEY` and variable `RELEASE_SYNC_APP_CLIENT_ID` for configuring the GitHub App used in release branch version sync. [[1]](diffhunk://#diff-7f6254f34e124b6ff67f63aacb73b5252aa8e2b8afe712f48cdd3b32a24f908cR80) [[2]](diffhunk://#diff-7f6254f34e124b6ff67f63aacb73b5252aa8e2b8afe712f48cdd3b32a24f908cR120)
* Added instructions for base64-encoding the GitHub App private key PEM file for use as a secret.
* Updated `docs/jira-workflow.md` to include the new `RELEASE_SYNC_APP_CLIENT_ID` variable for Jira workflow integration.