### PR TITLE
APP-43-Fix bugs

### DIFF
--- a/lib/database/src/database_repository.dart
+++ b/lib/database/src/database_repository.dart
@@ -1471,6 +1471,7 @@ class DatabaseNew {
                 await sendRecordingNew(recording, toSend);
               }
             }
+            return;
           }
 
           // Now (whether BEId exists already or has just been created) try sending each idle part at most once.
@@ -1485,11 +1486,9 @@ class DatabaseNew {
             }
             if (part.backendRecordingId == null && recording?.BEId != null) {
               part.backendRecordingId = recording!.BEId;
+              await updateRecordingPart(part);
             }
 
-            // Persist the sending flag immediately to avoid concurrent retries picking it up again.
-            part.sending = true;
-            await updateRecordingPart(part);
             await sendRecordingPartNew(part);
           }
         } catch (e, st) {

--- a/lib/localRecordings/recListItem.dart
+++ b/lib/localRecordings/recListItem.dart
@@ -190,6 +190,7 @@ class _RecordingItemState extends State<RecordingItem> {
         recordingId: recordingIdForPrompt,
         oncePerSession: false,
       );
+      if (!mounted) return;
       await _fetchRecordings();
     });
   }
@@ -405,6 +406,7 @@ class _RecordingItemState extends State<RecordingItem> {
       recordingId: recordingId,
       oncePerSession: false,
     );
+    if (!mounted) return;
     await _refreshRecordingState();
     await getParts();
   }
@@ -1194,6 +1196,7 @@ class _RecordingItemState extends State<RecordingItem> {
                                         recordingId: recordingId,
                                         oncePerSession: false,
                                       );
+                                      if (!mounted) return;
                                       await _fetchRecordings();
                                       return;
                                     }


### PR DESCRIPTION
This pull request introduces several small but important improvements to error handling and state management in the `database_repository.dart` and `recListItem.dart` files. The main focus is on ensuring proper state updates and preventing issues when widgets are unmounted, as well as improving the logic for updating recording parts.

**State management and error handling improvements:**

* Added `if (!mounted) return;` checks after asynchronous operations in `_RecordingItemState` methods to prevent setState calls on unmounted widgets, improving app stability. (`lib/localRecordings/recListItem.dart`) [[1]](diffhunk://#diff-121e51d5adfc2b2d6ebd888ba24c3336c93181fd463f3d78d30db78b2e5bd789R193) [[2]](diffhunk://#diff-121e51d5adfc2b2d6ebd888ba24c3336c93181fd463f3d78d30db78b2e5bd789R409) [[3]](diffhunk://#diff-121e51d5adfc2b2d6ebd888ba24c3336c93181fd463f3d78d30db78b2e5bd789R1199)

**Recording part update logic:**

* Updated logic in `DatabaseNew` to persist changes to `recordingPart` only when the `backendRecordingId` is set, and removed redundant updates to the `sending` flag, streamlining the backend sync process. (`lib/database/src/database_repository.dart`)
* Added an early return after sending all new recordings, clarifying control flow and preventing unnecessary processing. (`lib/database/src/database_repository.dart`)