### PR TITLE
APP-44 Show sending parts status

### DIFF
--- a/assets/lang/cs.json
+++ b/assets/lang/cs.json
@@ -308,6 +308,7 @@
     "emptyListMessage": "Zatím nemáte žádné záznamy",
     "status": {
       "sending": "Odesílání...",
+      "sendingParts": "Odesílání částí...",
       "checkingParts": "Kontrola částí...",
       "unsentParts": "Neodeslané části",
       "uploaded": "Nahráno",

--- a/assets/lang/de.json
+++ b/assets/lang/de.json
@@ -308,6 +308,7 @@
     "emptyListMessage": "Sie haben noch keine Aufnahmen",
     "status": {
       "sending": "Senden …",
+      "sendingParts": "Teile werden gesendet …",
       "checkingParts": "Teile werden geprüft …",
       "unsentParts": "Nicht gesendete Teile",
       "uploaded": "Hochgeladen",

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -310,6 +310,7 @@
     "emptyListMessage": "You don’t have any recordings yet",
     "status": {
       "sending": "Sending...",
+      "sendingParts": "Sending parts...",
       "checkingParts": "Checking parts...",
       "unsentParts": "Unsent parts",
       "uploaded": "Uploaded",

--- a/lib/localRecordings/recList.dart
+++ b/lib/localRecordings/recList.dart
@@ -358,7 +358,10 @@ class _RecordingScreenState extends State<RecordingScreen> with RouteAware {
                   color = rec.sent ? Colors.green : Colors.orange;
                 } else {
                   final parts = snapshot.data!;
-                  if (rec.sent && parts.any((p) => !p.sent)) {
+                  if (parts.any((p) => p.sending)) {
+                    status = '🔵';
+                    color = Colors.blue;
+                  } else if (rec.sent && parts.any((p) => !p.sent)) {
                     status = '❌';
                     color = Colors.red;
                   } else {
@@ -737,7 +740,12 @@ class _RecordingScreenState extends State<RecordingScreen> with RouteAware {
                                                     } else {
                                                       final parts =
                                                           snapshot.data!;
-                                                      if (rec.sent &&
+                                                      if (parts.any(
+                                                          (p) => p.sending)) {
+                                                        status = t(
+                                                            'recList.status.sendingParts');
+                                                        color = Colors.blue;
+                                                      } else if (rec.sent &&
                                                           parts.any(
                                                               (p) => !p.sent)) {
                                                         logger.w(


### PR DESCRIPTION
This pull request introduces improved status handling for recordings that are being sent in parts, along with corresponding localization updates. The main changes are the addition of a new "sending parts" status in the UI and translations for this status in multiple languages.

**Recording status logic updates:**

* Updated the status logic in `lib/localRecordings/recList.dart` to display a blue "sending parts" indicator when any part of a recording is in the process of being sent. The status text uses the new localized string, and the status color is set to blue. [[1]](diffhunk://#diff-1a803bbdd5a7e5c347d3d9d6e5f2b91c82e05ae40a83ae06c36b13caa85ed3b3L361-R364) [[2]](diffhunk://#diff-1a803bbdd5a7e5c347d3d9d6e5f2b91c82e05ae40a83ae06c36b13caa85ed3b3L740-R748)

**Localization updates:**

* Added the `sendingParts` status string to the English (`en.json`), Czech (`cs.json`), and German (`de.json`) localization files to support the new status in the UI. [[1]](diffhunk://#diff-23fb4cf7b20617af2a7b6077825d115f5e094f6f3513173a319706370e126530R313) [[2]](diffhunk://#diff-d488bb06df932fa8961b07dcf8b5c10a28571880513df3eb9c798bb8582f6d82R311) [[3]](diffhunk://#diff-6b2c49433059320fe28c284b7d36b8eeb41edb2bf613bab3336a48cc7147c92aR311)