### PR TITLE
APP-53 Opravit otevření obnovy hesla z odkazu

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -345,7 +345,9 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
       home: widget.homeOverride ?? Authorizator(),
       onGenerateRoute: (settings) {
         final name = settings.name ?? '';
-        switch (name) {
+        final uri = Uri.tryParse(name);
+        final path = uri?.path ?? name;
+        switch (path) {
           case '/ucet/email-neoveren':
             return MaterialPageRoute(
               settings: const RouteSettings(name: '/email-not-verified'),
@@ -358,7 +360,9 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
             );
           case '/ucet/obnova-hesla':
             final args = settings.arguments as Map<String, dynamic>?;
-            final token = args?['token'] as String? ?? '';
+            final token = args?['token'] as String? ??
+                uri?.queryParameters['token'] ??
+                '';
             return MaterialPageRoute(
               settings: const RouteSettings(name: '/reset-password'),
               builder: (_) => ChangePassword(jwt: token),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -35,8 +35,11 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:strnadi/auth/passReset/newPassword.dart';
 
 import 'package:strnadi/main.dart';
 
@@ -53,5 +56,31 @@ void main() {
 
     expect(find.byType(MaterialApp), findsOneWidget);
     expect(find.byKey(const Key('isolated-test-home')), findsOneWidget);
+  });
+
+  testWidgets('password reset deep link reads token from query parameters',
+      (WidgetTester tester) async {
+    const String token =
+        'eyJhbGciOiJub25lIn0.eyJzdWIiOiJiaXJkQGV4YW1wbGUudGVzdCJ9.signature';
+
+    await tester.pumpWidget(
+      const MyApp(
+        homeOverride: SizedBox(key: Key('isolated-test-home')),
+        enableLifecycleSideEffects: false,
+      ),
+    );
+    await tester.pump();
+
+    unawaited(
+      navigatorKey.currentState!.pushNamed(
+        '/ucet/obnova-hesla?token=$token',
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    final ChangePassword page =
+        tester.widget<ChangePassword>(find.byType(ChangePassword));
+    expect(page.jwt, token);
   });
 }


### PR DESCRIPTION
## Změna
- routování rozlišuje cestu URL od query parametrů
- token pro obnovu hesla se načte přímo z odkazu
- přidaný regresní widget test

## Ověření
- `flutter test --no-pub` — 1175 testů prošlo
- odkaz ověřen na iPhone 17e / iOS 26.5 při spuštěné i ukončené aplikaci

Jira: https://strnadi-status.atlassian.net/browse/APP-53