### PR TITLE
APP-55 Zpřístupnit mapu s uloženými daty offline

### DIFF
--- a/assets/lang/cs.json
+++ b/assets/lang/cs.json
@@ -471,6 +471,12 @@
       "title": "Načítají se nahrávky",
       "subtitle": "Body se na mapě objeví za okamžik."
     },
+    "offline": {
+      "savedData": "Zobrazuji poslední uložená data.",
+      "savedDataAt": "Zobrazuji uložená data z {time}.",
+      "noData": "Aktuální ani uložená data se nepodařilo načíst.",
+      "retry": "Načíst aktuální data znovu"
+    },
     "legend": {
       "title": "Legenda",
       "dialects": {

--- a/assets/lang/de.json
+++ b/assets/lang/de.json
@@ -471,6 +471,12 @@
       "title": "Aufnahmen werden geladen",
       "subtitle": "Die Markierungen erscheinen gleich auf der Karte."
     },
+    "offline": {
+      "savedData": "Die zuletzt gespeicherten Daten werden angezeigt.",
+      "savedDataAt": "Gespeicherte Daten vom {time} werden angezeigt.",
+      "noData": "Aktuelle oder gespeicherte Daten konnten nicht geladen werden.",
+      "retry": "Aktuelle Daten erneut laden"
+    },
     "legend": {
       "title": "Legende",
       "dialects": {

--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -474,6 +474,12 @@
       "title": "Loading recordings",
       "subtitle": "Markers will appear on the map in a moment."
     },
+    "offline": {
+      "savedData": "Showing the last saved data.",
+      "savedDataAt": "Showing data saved at {time}.",
+      "noData": "Current or saved data could not be loaded.",
+      "retry": "Load current data again"
+    },
     "legend": {
       "title": "Legend",
       "dialects": {

--- a/lib/map/filtered_parts_api_loader.dart
+++ b/lib/map/filtered_parts_api_loader.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:logger/logger.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:strnadi/api/controllers/filtered_recordings_controller.dart';
 import 'package:strnadi/database/Models/detectedDialect.dart';
 import 'package:strnadi/database/Models/filteredRecordingPart.dart';
@@ -10,10 +9,21 @@ class FilteredPartsBundle {
   const FilteredPartsBundle({
     required this.frps,
     required this.dds,
+    required this.isAvailable,
+    required this.sourcePayload,
   });
 
   final List<FilteredRecordingPart> frps;
   final List<DetectedDialect> dds;
+  final bool isAvailable;
+  final List<dynamic> sourcePayload;
+
+  static const FilteredPartsBundle unavailable = FilteredPartsBundle(
+    frps: <FilteredRecordingPart>[],
+    dds: <DetectedDialect>[],
+    isAvailable: false,
+    sourcePayload: <dynamic>[],
+  );
 }
 
 class FilteredPartsApiLoader {
@@ -26,6 +36,35 @@ class FilteredPartsApiLoader {
 
   final FilteredRecordingsController _controller;
   final Logger? _logger;
+
+  static FilteredPartsBundle parsePayload(List<dynamic> decoded) {
+    final frps = <FilteredRecordingPart>[];
+    final dds = <DetectedDialect>[];
+
+    for (final item in decoded) {
+      if (item is! Map<String, dynamic>) continue;
+      final frp = FilteredRecordingPart.fromBEJson(item);
+      frps.add(frp);
+
+      final List<dynamic>? dialects =
+          item['detectedDialects'] as List<dynamic>?;
+      if (dialects == null) continue;
+      for (final d in dialects) {
+        if (d is! Map<String, dynamic>) continue;
+        dds.add(DetectedDialect.fromBEJson(
+          d,
+          parentFilteredPartBEID: frp.BEId ?? -1,
+        ));
+      }
+    }
+
+    return FilteredPartsBundle(
+      frps: frps,
+      dds: dds,
+      isAvailable: true,
+      sourcePayload: List<dynamic>.from(decoded),
+    );
+  }
 
   Future<FilteredPartsBundle> fetch({
     int? recordingId,
@@ -44,61 +83,35 @@ class FilteredPartsApiLoader {
         return const FilteredPartsBundle(
           frps: <FilteredRecordingPart>[],
           dds: <DetectedDialect>[],
+          isAvailable: true,
+          sourcePayload: <dynamic>[],
         );
       }
       if (resp.statusCode != 200) {
-        _logger?.e(
-          '[MapV2] /recordings/filtered failed: ${resp.statusCode} body=${resp.data}',
+        _logger?.w(
+          '[MapV2] /recordings/filtered unavailable: ${resp.statusCode}',
         );
-        return const FilteredPartsBundle(
-          frps: <FilteredRecordingPart>[],
-          dds: <DetectedDialect>[],
-        );
+        return FilteredPartsBundle.unavailable;
       }
 
       final dynamic decoded =
           resp.data is String ? jsonDecode(resp.data as String) : resp.data;
       if (decoded is! List) {
         _logger?.w('[MapV2] /recordings/filtered returned non-list payload');
-        return const FilteredPartsBundle(
-          frps: <FilteredRecordingPart>[],
-          dds: <DetectedDialect>[],
-        );
+        return FilteredPartsBundle.unavailable;
       }
 
-      final frps = <FilteredRecordingPart>[];
-      final dds = <DetectedDialect>[];
-
-      for (final item in decoded) {
-        if (item is! Map<String, dynamic>) continue;
-        final frp = FilteredRecordingPart.fromBEJson(item);
-        frps.add(frp);
-
-        final List<dynamic>? dialects =
-            item['detectedDialects'] as List<dynamic>?;
-        if (dialects == null) continue;
-        for (final d in dialects) {
-          if (d is! Map<String, dynamic>) continue;
-          final row = DetectedDialect.fromBEJson(
-            d,
-            parentFilteredPartBEID: frp.BEId ?? -1,
-          );
-          dds.add(row);
-        }
-      }
+      final FilteredPartsBundle bundle = parsePayload(decoded);
 
       _logger?.i(
-        '[MapV2] /recordings/filtered parsed: FRPs=${frps.length}, DDs=${dds.length}',
+        '[MapV2] /recordings/filtered parsed: FRPs=${bundle.frps.length}, DDs=${bundle.dds.length}',
       );
-      return FilteredPartsBundle(frps: frps, dds: dds);
-    } catch (e, st) {
-      _logger?.e('[MapV2] /recordings/filtered exception: $e',
-          error: e, stackTrace: st);
-      Sentry.captureException(e, stackTrace: st);
-      return const FilteredPartsBundle(
-        frps: <FilteredRecordingPart>[],
-        dds: <DetectedDialect>[],
+      return bundle;
+    } catch (e) {
+      _logger?.w(
+        '[MapV2] /recordings/filtered unavailable: ${e.runtimeType}',
       );
+      return FilteredPartsBundle.unavailable;
     }
   }
 }

--- a/lib/map/map_data_cache.dart
+++ b/lib/map/map_data_cache.dart
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2025 Marian Pecqueur && Jan Drobílek
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:path_provider/path_provider.dart';
+
+class MapDataCacheEntry {
+  const MapDataCacheEntry({
+    required this.savedAt,
+    required this.recordingsPayload,
+    required this.filteredPartsPayload,
+  });
+
+  final DateTime savedAt;
+  final List<dynamic> recordingsPayload;
+  final List<dynamic> filteredPartsPayload;
+}
+
+abstract class MapDataCacheStore {
+  Future<String?> read(String key);
+
+  Future<void> write(String key, String contents);
+}
+
+class FileMapDataCacheStore implements MapDataCacheStore {
+  const FileMapDataCacheStore();
+
+  Future<File> _file(String key) async {
+    final Directory supportDirectory = await getApplicationSupportDirectory();
+    final Directory cacheDirectory =
+        Directory('${supportDirectory.path}/map-data-cache');
+    await cacheDirectory.create(recursive: true);
+    return File('${cacheDirectory.path}/$key.json');
+  }
+
+  @override
+  Future<String?> read(String key) async {
+    final File file = await _file(key);
+    if (!await file.exists()) return null;
+    return file.readAsString();
+  }
+
+  @override
+  Future<void> write(String key, String contents) async {
+    final File target = await _file(key);
+    final File temporary = File('${target.path}.tmp');
+    await temporary.writeAsString(contents, flush: true);
+    await temporary.rename(target.path);
+  }
+}
+
+class MapDataCache {
+  MapDataCache({
+    required this.scope,
+    MapDataCacheStore store = const FileMapDataCacheStore(),
+    DateTime Function()? now,
+    this.maximumEntryBytes = 48 * 1024 * 1024,
+  })  : _store = store,
+        _now = now ?? DateTime.now;
+
+  static const int schemaVersion = 1;
+
+  final String scope;
+  final MapDataCacheStore _store;
+  final DateTime Function() _now;
+  final int maximumEntryBytes;
+  Future<void> _pendingWrite = Future<void>.value();
+
+  String _key() {
+    final String scopeHash = sha256.convert(utf8.encode(scope)).toString();
+    return 'map-data-$scopeHash';
+  }
+
+  Future<MapDataCacheEntry?> load() async {
+    try {
+      final String? raw = await _store.read(_key());
+      if (raw == null || utf8.encode(raw).length > maximumEntryBytes) {
+        return null;
+      }
+      final dynamic decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic> ||
+          decoded['version'] != schemaVersion ||
+          decoded['scope'] != scope ||
+          decoded['recordings'] is! List ||
+          decoded['filteredParts'] is! List ||
+          decoded['savedAt'] is! String) {
+        return null;
+      }
+      final DateTime? savedAt = DateTime.tryParse(decoded['savedAt'] as String);
+      if (savedAt == null) return null;
+      return MapDataCacheEntry(
+        savedAt: savedAt,
+        recordingsPayload:
+            List<dynamic>.from(decoded['recordings'] as List<dynamic>),
+        filteredPartsPayload:
+            List<dynamic>.from(decoded['filteredParts'] as List<dynamic>),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<bool> save(
+    List<dynamic> recordingsPayload,
+    List<dynamic> filteredPartsPayload,
+  ) async {
+    try {
+      final List<dynamic> safeRecordings =
+          sanitizeMapRecordingsPayload(recordingsPayload);
+      final List<dynamic> safeFilteredParts =
+          sanitizeMapFilteredPartsPayload(filteredPartsPayload);
+      final String encoded = jsonEncode(<String, Object?>{
+        'version': schemaVersion,
+        'scope': scope,
+        'savedAt': _now().toUtc().toIso8601String(),
+        'recordings': safeRecordings,
+        'filteredParts': safeFilteredParts,
+      });
+      if (utf8.encode(encoded).length > maximumEntryBytes) {
+        return false;
+      }
+      final Future<void> write = _pendingWrite.then(
+        (_) => _store.write(_key(), encoded),
+      );
+      _pendingWrite = write.catchError((_) {});
+      await write;
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+}
+
+List<dynamic> sanitizeMapRecordingsPayload(List<dynamic> payload) {
+  return payload.whereType<Map<String, dynamic>>().map((recording) {
+    final List<dynamic> parts =
+        (recording['parts'] as List<dynamic>? ?? const <dynamic>[])
+            .whereType<Map<String, dynamic>>()
+            .map(
+              (part) => _pickFields(part, const <String>[
+                'id',
+                'length',
+                'recordingId',
+                'startDate',
+                'endDate',
+                'gpsLatitudeStart',
+                'gpsLatitudeEnd',
+                'gpsLongitudeStart',
+                'gpsLongitudeEnd',
+                'square',
+              ]),
+            )
+            .toList(growable: false);
+    return <String, Object?>{
+      ..._pickFields(recording, const <String>[
+        'id',
+        'userId',
+        'createdAt',
+        'estimatedBirdsCount',
+        'device',
+        'byApp',
+        'note',
+        'name',
+        'expectedPartsCount',
+        'totalSeconds',
+      ]),
+      'parts': parts,
+    };
+  }).toList(growable: false);
+}
+
+List<dynamic> sanitizeMapFilteredPartsPayload(List<dynamic> payload) {
+  return payload.whereType<Map<String, dynamic>>().map((filteredPart) {
+    final List<dynamic> dialects =
+        (filteredPart['detectedDialects'] as List<dynamic>? ??
+                const <dynamic>[])
+            .whereType<Map<String, dynamic>>()
+            .map(
+              (dialect) => _pickFields(dialect, const <String>[
+                'id',
+                'userGuessDialectId',
+                'userGuessDialect',
+                'confirmedDialectId',
+                'confirmedDialect',
+                'predictedDialectId',
+                'predictedDialect',
+              ]),
+            )
+            .toList(growable: false);
+    return <String, Object?>{
+      ..._pickFields(filteredPart, const <String>[
+        'id',
+        'recordingId',
+        'startDate',
+        'endDate',
+        'state',
+        'representantFlag',
+        'parentId',
+      ]),
+      'detectedDialects': dialects,
+    };
+  }).toList(growable: false);
+}
+
+Map<String, Object?> _pickFields(
+  Map<String, dynamic> source,
+  List<String> fields,
+) {
+  return <String, Object?>{
+    for (final String field in fields)
+      if (source.containsKey(field)) field: source[field],
+  };
+}

--- a/lib/map/mapv2.dart
+++ b/lib/map/mapv2.dart
@@ -46,6 +46,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:strnadi/api/controllers/recordings_controller.dart';
 import 'package:strnadi/api/controllers/user_controller.dart';
 import 'package:strnadi/map/filtered_parts_api_loader.dart';
+import 'package:strnadi/map/map_data_cache.dart';
 import 'package:strnadi/map/RecordingPage.dart';
 import 'package:strnadi/map/map_async_request_state.dart';
 import 'package:strnadi/map/mapUtils/dialect_marker_selection.dart';
@@ -103,6 +104,16 @@ class _RecordingDialectSelection {
   });
 }
 
+class _DialectRefreshResult {
+  const _DialectRefreshResult({
+    required this.isCurrentServerData,
+    this.serverPayload,
+  });
+
+  final bool isCurrentServerData;
+  final List<dynamic>? serverPayload;
+}
+
 class MapScreenV2 extends StatefulWidget {
   const MapScreenV2({Key? key}) : super(key: key);
 
@@ -116,6 +127,7 @@ class _MapScreenV2State extends State<MapScreenV2> {
   static const UserController _userController = UserController();
   final FilteredPartsApiLoader _filteredPartsApiLoader =
       FilteredPartsApiLoader(logger: logger);
+  late final MapDataCache _mapDataCache;
 
   late bool _clusterPoints = false;
 
@@ -125,6 +137,9 @@ class _MapScreenV2State extends State<MapScreenV2> {
   List<DetectedDialect> _cachedDetectedDialects = [];
   bool _hasCachedDialectData = false;
   bool _isLoadingRecordings = true;
+  bool _isUsingSavedMapData = false;
+  bool _mapRefreshFailed = false;
+  DateTime? _savedMapDataAt;
   final MapLoadingTracker _mapLoadingTracker = MapLoadingTracker();
   int? _recordingsLoadingToken;
   int? _dialectRefreshLoadingToken;
@@ -406,6 +421,9 @@ class _MapScreenV2State extends State<MapScreenV2> {
   @override
   void initState() {
     super.initState();
+    _mapDataCache = MapDataCache(
+      scope: '${Config.hostEnvironment.name}|${Config.host}',
+    );
     _loadGuestStatus();
     final LatLng? lastKnownPosition = LocationService().lastKnownPosition;
     if (lastKnownPosition != null) {
@@ -415,7 +433,7 @@ class _MapScreenV2State extends State<MapScreenV2> {
 
     unawaited(_getCurrentLocation());
 
-    unawaited(getRecordings());
+    unawaited(_loadSavedMapDataThenRefresh());
 
     // Subscribe to the centralized location stream.
     _positionStreamSubscription =
@@ -444,6 +462,120 @@ class _MapScreenV2State extends State<MapScreenV2> {
     // Warm legend codes from BE (non-blocking). UI shows defaults immediately.
     // When BE responds, we update the list without showing an empty placeholder.
     unawaited(_refreshLegendCodes());
+  }
+
+  Future<int?> _applyRecordingsPayload({
+    required List<dynamic> data,
+    required int requestId,
+  }) async {
+    final String responseBody = jsonEncode(data);
+    final List<Part> parts = getParts(responseBody);
+    final List<Recording> recordings = await GetRecordings(responseBody);
+    final int totalLength = parts.fold<int>(
+      0,
+      (int total, Part part) => total + (part.length ?? 0),
+    );
+    if (!_isCurrentRecordingsRequest(requestId)) return null;
+
+    length = totalLength;
+    final int dataGeneration = ++_recordingDataGeneration;
+    _recordingsByBeId
+      ..clear()
+      ..addEntries(
+        recordings
+            .where((recording) => recording.BEId != null)
+            .map((recording) => MapEntry(recording.BEId!, recording)),
+      );
+    _recLocalToBE.clear();
+    for (final Recording recording in recordings) {
+      if (recording.id != null && recording.BEId != null) {
+        _recLocalToBE[recording.id!] = recording.BEId!;
+      }
+    }
+    setState(() {
+      _recordings = parts;
+      _fullRecordings = recordings;
+      _visibleMarkers = const <Marker>[];
+    });
+    return dataGeneration;
+  }
+
+  Future<void> _loadSavedMapDataThenRefresh() async {
+    final int requestId = ++_activeRecordingsRequestId;
+    try {
+      final MapDataCacheEntry? entry = await _mapDataCache.load();
+      if (!_isCurrentRecordingsRequest(requestId)) return;
+
+      if (entry != null) {
+        final int? dataGeneration = await _applyRecordingsPayload(
+          data: entry.recordingsPayload,
+          requestId: requestId,
+        );
+        if (dataGeneration != null && _isCurrentRecordingsRequest(requestId)) {
+          setState(() {
+            _isUsingSavedMapData = true;
+            _savedMapDataAt = entry.savedAt;
+          });
+
+          try {
+            final FilteredPartsBundle bundle =
+                FilteredPartsApiLoader.parsePayload(
+              entry.filteredPartsPayload,
+            );
+            _cachedFilteredParts = bundle.frps;
+            _cachedDetectedDialects = bundle.dds;
+            _hasCachedDialectData = true;
+            await _fetchDialects(
+              refreshFromApi: false,
+              recordingsRequestId: requestId,
+              dataGeneration: dataGeneration,
+            );
+          } catch (_) {
+            await _rebuildMapMarkers();
+          }
+        }
+      }
+    } catch (error, stackTrace) {
+      logger.w(
+        '[MapV2] Saved map data could not be loaded.',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    if (mounted) {
+      await getRecordings();
+    }
+  }
+
+  void _setMapRefreshFailed() {
+    if (!mounted) return;
+    setState(() {
+      _mapRefreshFailed = true;
+    });
+  }
+
+  void _setMapDataCurrent() {
+    if (!mounted) return;
+    setState(() {
+      _isUsingSavedMapData = false;
+      _mapRefreshFailed = false;
+      _savedMapDataAt = null;
+    });
+  }
+
+  String _savedMapDataMessage() {
+    final DateTime? savedAt = _savedMapDataAt?.toLocal();
+    if (savedAt == null) return t('map.offline.savedData');
+    String twoDigits(int value) => value.toString().padLeft(2, '0');
+    final String time =
+        '${savedAt.day}.${savedAt.month}.${savedAt.year} ${twoDigits(savedAt.hour)}:${twoDigits(savedAt.minute)}';
+    return t('map.offline.savedDataAt').replaceAll('{time}', time);
+  }
+
+  String _mapAvailabilityMessage() {
+    if (_isUsingSavedMapData) return _savedMapDataMessage();
+    return t('map.offline.noData');
   }
 
   Future<void> fetchClusters({int? dataGeneration}) async {
@@ -537,6 +669,11 @@ class _MapScreenV2State extends State<MapScreenV2> {
   Future<void> getRecordings() async {
     final int requestId = ++_activeRecordingsRequestId;
     final int loadingToken = _beginRecordingsLoading();
+    if (mounted) {
+      setState(() {
+        _mapRefreshFailed = false;
+      });
+    }
     try {
       int? userId;
       //String? email;
@@ -585,61 +722,52 @@ class _MapScreenV2State extends State<MapScreenV2> {
         if (decoded is! List) {
           logger
               .e('Failed to parse recordings payload: ${decoded.runtimeType}');
+          _setMapRefreshFailed();
           return;
         }
         final List<dynamic> data = decoded;
-        final String responseBody = response.data is String
-            ? response.data as String
-            : jsonEncode(data);
-        final List<Part> parts = getParts(jsonEncode(data));
-        final List<Recording> recordings = await GetRecordings(responseBody);
-
-        final int totalLength = parts.fold<int>(
-          0,
-          (int total, Part part) => total + (part.length ?? 0),
-        );
-        if (!_isCurrentRecordingsRequest(requestId)) {
+        final FilteredPartsBundle filteredParts =
+            await _filteredPartsApiLoader.fetch(verified: false);
+        if (!_isCurrentRecordingsRequest(requestId)) return;
+        if (!filteredParts.isAvailable) {
+          _setMapRefreshFailed();
           return;
         }
-        length = totalLength;
-        final int dataGeneration = ++_recordingDataGeneration;
-        _recordingsByBeId
-          ..clear()
-          ..addEntries(
-            recordings
-                .where((recording) => recording.BEId != null)
-                .map((recording) => MapEntry(recording.BEId!, recording)),
-          );
-        // Build local->BE id map for consistent lookups
-        _recLocalToBE.clear();
-        for (final r in recordings) {
-          if (r.id != null && r.BEId != null) {
-            _recLocalToBE[r.id!] = r.BEId!;
-          }
-        }
-        setState(() {
-          _recordings = parts;
-          _fullRecordings = recordings;
-          _visibleMarkers = const <Marker>[];
-        });
-        logger.i(
-            '[MapV2] getRecordings(): parts=${parts.length}, totalLength=$length');
-        logger.i('[MapV2] getRecordings(): local->BE map size=' +
-            _recLocalToBE.length.toString());
-        logger
-            .i('[MapV2] getRecordings(): fullRecordings=${recordings.length}');
-        await _fetchDialects(
-          refreshFromApi: true,
+        final int? dataGeneration = await _applyRecordingsPayload(
+          data: data,
+          requestId: requestId,
+        );
+        if (dataGeneration == null) return;
+        final _DialectRefreshResult dialectRefresh = await _fetchDialects(
+          refreshedBundle: filteredParts,
           recordingsRequestId: requestId,
           dataGeneration: dataGeneration,
         );
+        if (!_isCurrentRecordingsRequest(requestId)) return;
+        if (dialectRefresh.isCurrentServerData) {
+          if (_recordingAuthorFilter == 'all' &&
+              dialectRefresh.serverPayload != null) {
+            final bool saved = await _mapDataCache.save(
+              data,
+              dialectRefresh.serverPayload!,
+            );
+            if (!saved) {
+              logger.w('[MapV2] Current map snapshot could not be cached.');
+            }
+            if (!_isCurrentRecordingsRequest(requestId)) return;
+          }
+          _setMapDataCurrent();
+        } else {
+          _setMapRefreshFailed();
+        }
       } else {
-        logger.e(
-            'Failed to fetch recordings ${response.statusCode} | ${response.data}');
+        logger.w('Failed to fetch recordings (${response.statusCode}).');
+        _setMapRefreshFailed();
       }
     } catch (error, stackTrace) {
-      logger.e("Error generariong map $error",
+      logger.w('Current map data could not be loaded.',
           error: error, stackTrace: stackTrace);
+      _setMapRefreshFailed();
     } finally {
       _finishRecordingsLoading(loadingToken);
     }
@@ -656,6 +784,9 @@ class _MapScreenV2State extends State<MapScreenV2> {
     _cachedFilteredParts = const <FilteredRecordingPart>[];
     _cachedDetectedDialects = const <DetectedDialect>[];
     _hasCachedDialectData = false;
+    _isUsingSavedMapData = false;
+    _mapRefreshFailed = false;
+    _savedMapDataAt = null;
     _dialectsByRecording = <int, _RecordingDialectSelection>{};
     _hiddenRecordingIds = <int>{};
     _recLocalToBE.clear();
@@ -670,8 +801,9 @@ class _MapScreenV2State extends State<MapScreenV2> {
     });
   }
 
-  Future<void> _fetchDialects({
+  Future<_DialectRefreshResult> _fetchDialects({
     bool refreshFromApi = true,
+    FilteredPartsBundle? refreshedBundle,
     required int recordingsRequestId,
     required int dataGeneration,
   }) async {
@@ -686,22 +818,40 @@ class _MapScreenV2State extends State<MapScreenV2> {
       // Always fetch all FRPs from BE to keep map filtering fully client-side.
       final List<FilteredRecordingPart> frps;
       final List<DetectedDialect> dds;
-      if (refreshFromApi || !_hasCachedDialectData) {
-        final api = await _filteredPartsApiLoader.fetch(
-          verified: false,
-        );
+      bool isCurrentServerData = true;
+      List<dynamic>? serverPayload;
+      if (refreshedBundle != null) {
+        frps = refreshedBundle.frps;
+        dds = refreshedBundle.dds;
+        _cachedFilteredParts = frps;
+        _cachedDetectedDialects = dds;
+        _hasCachedDialectData = true;
+        serverPayload = refreshedBundle.sourcePayload;
+      } else if (refreshFromApi || !_hasCachedDialectData) {
+        final FilteredPartsBundle api =
+            await _filteredPartsApiLoader.fetch(verified: false);
         if (!_isCurrentDialectRequest(
           dialectRequestId: dialectRequestId,
           recordingsRequestId: recordingsRequestId,
           dataGeneration: dataGeneration,
         )) {
-          return;
+          return const _DialectRefreshResult(isCurrentServerData: false);
         }
-        frps = api.frps;
-        dds = api.dds;
-        _cachedFilteredParts = frps;
-        _cachedDetectedDialects = dds;
-        _hasCachedDialectData = true;
+        if (!api.isAvailable) {
+          if (!_hasCachedDialectData) {
+            return const _DialectRefreshResult(isCurrentServerData: false);
+          }
+          frps = _cachedFilteredParts;
+          dds = _cachedDetectedDialects;
+          isCurrentServerData = false;
+        } else {
+          frps = api.frps;
+          dds = api.dds;
+          _cachedFilteredParts = frps;
+          _cachedDetectedDialects = dds;
+          _hasCachedDialectData = true;
+          serverPayload = api.sourcePayload;
+        }
       } else {
         frps = _cachedFilteredParts;
         dds = _cachedDetectedDialects;
@@ -861,7 +1011,7 @@ class _MapScreenV2State extends State<MapScreenV2> {
         recordingsRequestId: recordingsRequestId,
         dataGeneration: dataGeneration,
       )) {
-        return;
+        return const _DialectRefreshResult(isCurrentServerData: false);
       }
       setState(() {
         _dialectsByRecording = byRecording;
@@ -877,10 +1027,15 @@ class _MapScreenV2State extends State<MapScreenV2> {
         'missingBEId=$recordingsWithoutBackendId',
       );
       await _rebuildMapMarkers();
+      return _DialectRefreshResult(
+        isCurrentServerData: isCurrentServerData,
+        serverPayload: serverPayload,
+      );
     } catch (e, stackTrace) {
       logger.e('Failed to fetch representative dialects: ' + e.toString(),
           error: e, stackTrace: stackTrace);
       Sentry.captureException(e, stackTrace: stackTrace);
+      return const _DialectRefreshResult(isCurrentServerData: false);
     }
   }
 
@@ -1323,6 +1478,60 @@ class _MapScreenV2State extends State<MapScreenV2> {
                     ),
                   ),
                 ),
+              if (_isUsingSavedMapData ||
+                  (_mapRefreshFailed && !_isLoadingRecordings))
+                Positioned(
+                  top: _isLoadingRecordings ? 216 : 140,
+                  left: 16,
+                  right: 16,
+                  child: Center(
+                    child: Material(
+                      color: const Color(0xFFFDF3D8),
+                      elevation: 3,
+                      borderRadius: BorderRadius.circular(12),
+                      child: Container(
+                        constraints: const BoxConstraints(maxWidth: 420),
+                        padding: const EdgeInsets.only(
+                          left: 12,
+                          top: 8,
+                          bottom: 8,
+                          right: 4,
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            const Icon(
+                              Icons.cloud_off_outlined,
+                              size: 18,
+                              color: Color(0xFF765B13),
+                            ),
+                            const SizedBox(width: 8),
+                            Flexible(
+                              child: Text(
+                                _mapAvailabilityMessage(),
+                                style: const TextStyle(
+                                  color: Color(0xFF5C470F),
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                            ),
+                            if (_mapRefreshFailed && !_isLoadingRecordings)
+                              IconButton(
+                                tooltip: t('map.offline.retry'),
+                                visualDensity: VisualDensity.compact,
+                                onPressed: getRecordings,
+                                icon: const Icon(
+                                  Icons.refresh,
+                                  color: Color(0xFF765B13),
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
               Positioned(
                 top: 80,
                 left: 16,
@@ -1575,7 +1784,11 @@ class _MapScreenV2State extends State<MapScreenV2> {
     });
 
     if (shouldReloadRecordings) {
-      unawaited(getRecordings());
+      if (_recordingAuthorFilter == 'all') {
+        unawaited(_loadSavedMapDataThenRefresh());
+      } else {
+        unawaited(getRecordings());
+      }
       return;
     }
     if (shouldRefreshDialects) {

--- a/test/map/map_async_request_state_test.dart
+++ b/test/map/map_async_request_state_test.dart
@@ -133,10 +133,13 @@ void main() {
     });
 
     test('guards stale recording responses before mutating shared length', () {
-      final int methodStart =
-          source.indexOf('Future<void> getRecordings() async');
-      final int methodEnd =
-          source.indexOf('void _clearRecordingResults()', methodStart);
+      final int methodStart = source.indexOf(
+        'Future<int?> _applyRecordingsPayload({',
+      );
+      final int methodEnd = source.indexOf(
+        'Future<void> _loadSavedMapDataThenRefresh()',
+        methodStart,
+      );
       final String method = source.substring(methodStart, methodEnd);
 
       final int localCalculation = method.indexOf('final int totalLength');
@@ -152,8 +155,28 @@ void main() {
       expect(method, isNot(contains('length +=')));
     });
 
+    test('keeps saved markers until both current payloads are available', () {
+      final int methodStart =
+          source.indexOf('Future<void> getRecordings() async');
+      final int methodEnd =
+          source.indexOf('void _clearRecordingResults()', methodStart);
+      final String method = source.substring(methodStart, methodEnd);
+
+      final int recordingsAwait =
+          method.indexOf('_recordingsController.fetchRecordings(');
+      final int filteredPartsAwait =
+          method.indexOf('_filteredPartsApiLoader.fetch(', recordingsAwait);
+      final int applyCurrentPayload =
+          method.indexOf('_applyRecordingsPayload(', filteredPartsAwait);
+
+      expect(recordingsAwait, greaterThanOrEqualTo(0));
+      expect(filteredPartsAwait, greaterThan(recordingsAwait));
+      expect(applyCurrentPayload, greaterThan(filteredPartsAwait));
+    });
+
     test('guards API results before updating dialect caches and selection', () {
-      final int methodStart = source.indexOf('Future<void> _fetchDialects({');
+      final int methodStart =
+          source.indexOf('Future<_DialectRefreshResult> _fetchDialects({');
       final int methodEnd =
           source.indexOf('List<String> _dialectsForRecordingId', methodStart);
       final String method = source.substring(methodStart, methodEnd);
@@ -200,8 +223,9 @@ void main() {
     });
 
     test('wires fallback visibility into the final map marker policy', () {
-      final int dialectMethodStart =
-          source.indexOf('Future<void> _fetchDialects({');
+      final int dialectMethodStart = source.indexOf(
+        'Future<_DialectRefreshResult> _fetchDialects({',
+      );
       final int dialectMethodEnd = source.indexOf(
         'List<String> _dialectsForRecordingId',
         dialectMethodStart,

--- a/test/map/map_data_cache_test.dart
+++ b/test/map/map_data_cache_test.dart
@@ -1,0 +1,253 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:strnadi/map/filtered_parts_api_loader.dart';
+import 'package:strnadi/map/map_data_cache.dart';
+
+class _MemoryMapDataCacheStore implements MapDataCacheStore {
+  final Map<String, String> values = <String, String>{};
+  bool failWrites = false;
+
+  @override
+  Future<String?> read(String key) async => values[key];
+
+  @override
+  Future<void> write(String key, String contents) async {
+    if (failWrites) throw const FileSystemExceptionForTest();
+    values[key] = contents;
+  }
+}
+
+class FileSystemExceptionForTest implements Exception {
+  const FileSystemExceptionForTest();
+}
+
+void main() {
+  group('MapDataCache', () {
+    test('stores and restores a scoped map data snapshot', () async {
+      final _MemoryMapDataCacheStore store = _MemoryMapDataCacheStore();
+      final DateTime savedAt = DateTime.utc(2026, 8, 12, 9, 30);
+      final MapDataCache cache = MapDataCache(
+        scope: 'prod|api.strnadi.cz',
+        store: store,
+        now: () => savedAt,
+      );
+      final List<dynamic> payload = <dynamic>[
+        <String, Object?>{'id': 8934, 'parts': <dynamic>[]},
+      ];
+
+      expect(
+        await cache.save(payload, const <dynamic>[]),
+        isTrue,
+      );
+      final MapDataCacheEntry? restored = await cache.load();
+
+      expect(restored, isNotNull);
+      expect(restored!.savedAt, savedAt);
+      expect(restored.recordingsPayload, payload);
+      expect(restored.filteredPartsPayload, isEmpty);
+    });
+
+    test('keeps production and development snapshots separate', () async {
+      final _MemoryMapDataCacheStore store = _MemoryMapDataCacheStore();
+      final MapDataCache production = MapDataCache(
+        scope: 'prod|api.strnadi.cz',
+        store: store,
+      );
+      final MapDataCache development = MapDataCache(
+        scope: 'dev|dev-api.strnadi.cz',
+        store: store,
+      );
+
+      await production.save(<dynamic>[
+        <String, Object?>{'id': 1}
+      ], const <dynamic>[]);
+
+      expect(await development.load(), isNull);
+    });
+
+    test('ignores corrupt and oversized entries', () async {
+      final _MemoryMapDataCacheStore corruptStore = _MemoryMapDataCacheStore();
+      final MapDataCache corruptCache = MapDataCache(
+        scope: 'prod|api.strnadi.cz',
+        store: corruptStore,
+      );
+      await corruptCache.save(<dynamic>[
+        <String, Object?>{'id': 1}
+      ], const <dynamic>[]);
+      corruptStore.values.updateAll((_, __) => '{not-json');
+
+      expect(
+        await corruptCache.load(),
+        isNull,
+      );
+
+      final _MemoryMapDataCacheStore smallStore = _MemoryMapDataCacheStore();
+      final MapDataCache smallCache = MapDataCache(
+        scope: 'prod|api.strnadi.cz',
+        store: smallStore,
+        maximumEntryBytes: 80,
+      );
+      expect(
+        await smallCache.save(
+          <dynamic>[
+            <String, Object?>{'value': 'x' * 100}
+          ],
+          const <dynamic>[],
+        ),
+        isFalse,
+      );
+      expect(smallStore.values, isEmpty);
+    });
+
+    test('does not report a failed write as cached', () async {
+      final _MemoryMapDataCacheStore store = _MemoryMapDataCacheStore()
+        ..failWrites = true;
+      final MapDataCache cache = MapDataCache(
+        scope: 'prod|api.strnadi.cz',
+        store: store,
+      );
+
+      expect(
+        await cache.save(const <dynamic>[], const <dynamic>[]),
+        isFalse,
+      );
+    });
+
+    test('serializes overlapping writes and keeps the newest snapshot',
+        () async {
+      final _MemoryMapDataCacheStore store = _MemoryMapDataCacheStore();
+      final MapDataCache cache = MapDataCache(
+        scope: 'prod|api.strnadi.cz',
+        store: store,
+      );
+
+      final Future<bool> first = cache.save(
+        <dynamic>[
+          <String, Object?>{'id': 1}
+        ],
+        const <dynamic>[],
+      );
+      final Future<bool> second = cache.save(
+        <dynamic>[
+          <String, Object?>{'id': 2}
+        ],
+        const <dynamic>[],
+      );
+
+      expect(await Future.wait(<Future<bool>>[first, second]),
+          everyElement(isTrue));
+      final MapDataCacheEntry? restored = await cache.load();
+      expect(restored!.recordingsPayload.single['id'], 2);
+    });
+
+    test('persists only fields required by the map', () async {
+      final _MemoryMapDataCacheStore store = _MemoryMapDataCacheStore();
+      final MapDataCache cache = MapDataCache(
+        scope: 'prod|api.strnadi.cz',
+        store: store,
+      );
+
+      await cache.save(
+        <dynamic>[
+          <String, Object?>{
+            'id': 8934,
+            'createdAt': '2026-08-12T09:00:00Z',
+            'estimatedBirdsCount': 1,
+            'byApp': true,
+            'expectedPartsCount': 1,
+            'totalSeconds': 5,
+            'mail': 'must-not-be-cached@example.test',
+            'parts': <dynamic>[
+              <String, Object?>{
+                'id': 1,
+                'recordingId': 8934,
+                'startDate': '2026-08-12T09:00:00Z',
+                'endDate': '2026-08-12T09:00:05Z',
+                'gpsLatitudeStart': 50.0,
+                'gpsLatitudeEnd': 50.0,
+                'gpsLongitudeStart': 14.0,
+                'gpsLongitudeEnd': 14.0,
+                'dataBase64': 'must-not-be-cached',
+              },
+            ],
+          },
+        ],
+        <dynamic>[
+          <String, Object?>{
+            'id': 12,
+            'recordingId': 8934,
+            'startDate': '2026-08-12T09:00:00Z',
+            'endDate': '2026-08-12T09:00:05Z',
+            'state': 6,
+            'representantFlag': true,
+            'reviewerEmail': 'must-not-be-cached@example.test',
+            'detectedDialects': <dynamic>[
+              <String, Object?>{
+                'id': 24,
+                'predictedDialect': 'BC',
+                'reviewerId': 99,
+              },
+            ],
+          },
+        ],
+      );
+
+      final MapDataCacheEntry restored = (await cache.load())!;
+      final Map<String, dynamic> recording =
+          restored.recordingsPayload.single as Map<String, dynamic>;
+      final Map<String, dynamic> part =
+          (recording['parts'] as List<dynamic>).single as Map<String, dynamic>;
+      final Map<String, dynamic> filteredPart =
+          restored.filteredPartsPayload.single as Map<String, dynamic>;
+      final Map<String, dynamic> dialect =
+          (filteredPart['detectedDialects'] as List<dynamic>).single
+              as Map<String, dynamic>;
+
+      expect(recording, isNot(contains('mail')));
+      expect(part, isNot(contains('dataBase64')));
+      expect(filteredPart, isNot(contains('reviewerEmail')));
+      expect(dialect, isNot(contains('reviewerId')));
+      expect(dialect['predictedDialect'], 'BC');
+    });
+  });
+
+  group('FilteredPartsApiLoader.parsePayload', () {
+    test('restores filtered parts and their dialects without API or DB', () {
+      final List<dynamic> payload = jsonDecode('''
+        [{
+          "id": 12,
+          "recordingId": 8934,
+          "startDate": "2026-08-12T09:00:00Z",
+          "endDate": "2026-08-12T09:00:05Z",
+          "state": 6,
+          "representantFlag": true,
+          "detectedDialects": [{
+            "id": 24,
+            "predictedDialect": "BC"
+          }]
+        }]
+      ''') as List<dynamic>;
+
+      final FilteredPartsBundle bundle =
+          FilteredPartsApiLoader.parsePayload(payload);
+
+      expect(bundle.isAvailable, isTrue);
+      expect(bundle.frps, hasLength(1));
+      expect(bundle.frps.single.recordingBEID, 8934);
+      expect(bundle.dds, hasLength(1));
+      expect(bundle.dds.single.filteredPartBEID, 12);
+      expect(bundle.dds.single.predictedDialect, 'BC');
+      expect(bundle.sourcePayload, payload);
+    });
+
+    test('distinguishes an unavailable response from a valid empty one', () {
+      final FilteredPartsBundle empty =
+          FilteredPartsApiLoader.parsePayload(<dynamic>[]);
+
+      expect(empty.isAvailable, isTrue);
+      expect(empty.frps, isEmpty);
+      expect(FilteredPartsBundle.unavailable.isAvailable, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Co se změnilo

Mapa si po úspěšném načtení atomicky uloží poslední nahrávky a zpracované části potřebné pro zobrazení bodů a nářečí. Při pomalém nebo nedostupném připojení je okamžitě zobrazí, označí jejich stáří a na pozadí se pokusí získat aktuální data.

Při neúspěšné aktualizaci zůstanou uložená data na mapě a uživatel může načtení zopakovat. Produkční a vývojová data jsou oddělená. Cache obsahuje jen pole potřebná pro mapu, nikoli zvuk nebo e-mailové adresy.

Očekávaný výpadek mapového endpointu se loguje pouze stručně bez těla odpovědi a bez odesílání chybové telemetrie.

Mapové dlaždice Mapy.com se trvale neukládají; licenční podmínky poskytovatele ukládání dlaždic zakazují.

## Co otestovat

- Otevřít mapu online, nechat ji načíst a potom ji otevřít při vypnutém internetu. Ověřit, že jsou vidět poslední uložená data a informace o jejich stáří.
- Na pomalém připojení ověřit, že starší data zůstanou použitelná během načítání a po dokončení je nahradí aktuální data.
- Při neúspěšném načtení použít tlačítko pro opakování a ověřit, že uložená data nezmizí.

## Ověření

- `flutter test`: 1 184 testů prošlo
- Cílené mapové testy: 23 testů prošlo
- `dart analyze` nových cache souborů: bez nálezů
- Mapa ručně ověřena v iOS simulátoru (aktuální data, pomalé API, nedostupné API, opakování načtení)
- Jira: https://strnadi-status.atlassian.net/browse/APP-55